### PR TITLE
[cudapoa] compute kernel for computing distance vector R for adaptive banding 

### DIFF
--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -243,6 +243,8 @@ public:
         offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa) * max_nodes_per_window_ * max_poas_);
         graph_details_d->sorted_poa_node_map = reinterpret_cast<decltype(graph_details_d->sorted_poa_node_map)>(&block_data_d_[offset_d_]);
         offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa_node_map) * max_nodes_per_window_ * max_poas_);
+        graph_details_d->node_distance_to_head = reinterpret_cast<decltype(graph_details_d->node_distance_to_head)>(&block_data_d_[offset_d_]);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->node_distance_to_head) * max_nodes_per_window_ * max_poas_);
         graph_details_d->sorted_poa_local_edge_count = reinterpret_cast<decltype(graph_details_d->sorted_poa_local_edge_count)>(&block_data_d_[offset_d_]);
         offset_d_ += cudautils::align<int64_t, 8>(sizeof(*graph_details_d->sorted_poa_local_edge_count) * max_nodes_per_window_ * max_poas_);
         if (output_mask_ & OutputType::consensus)
@@ -350,6 +352,7 @@ protected:
         device_size_per_poa += sizeof(*GraphDetails<SizeT>::outgoing_edge_weights) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * poa_count;                                                                   // graph_details_d_->outgoing_edge_weights
         device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa) * max_nodes_per_window_ * poa_count;                                                                                                       // graph_details_d_->sorted_poa
         device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa_node_map) * max_nodes_per_window_ * poa_count;                                                                                              // graph_details_d_->sorted_poa_node_map
+        device_size_per_poa += sizeof(*GraphDetails<SizeT>::node_distance_to_head) * max_nodes_per_window_ * poa_count;                                                                                            // graph_details_d_->node_distance_to_head
         device_size_per_poa += sizeof(*GraphDetails<SizeT>::sorted_poa_local_edge_count) * max_nodes_per_window_ * poa_count;                                                                                      // graph_details_d_->sorted_poa_local_edge_count
         device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(*GraphDetails<SizeT>::consensus_scores) * max_nodes_per_window_ * poa_count : 0;                                                    // graph_details_d_->consensus_scores
         device_size_per_poa += (output_mask_ & OutputType::consensus) ? sizeof(*GraphDetails<SizeT>::consensus_predecessors) * max_nodes_per_window_ * poa_count : 0;                                              // graph_details_d_->consensus_predecessors

--- a/cudapoa/src/cudapoa_adaptive_banding.cu
+++ b/cudapoa/src/cudapoa_adaptive_banding.cu
@@ -1,0 +1,91 @@
+/*
+* Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#include "cudapoa_kernels.cuh"
+
+#include <claragenomics/utils/cudautils.hpp>
+
+#include <stdio.h>
+
+namespace claraparabricks
+{
+
+namespace genomeworks
+{
+
+namespace cudapoa
+{
+
+/**
+ * @brief Device function for computing outgoing path length of each node to the end of the POA graph.
+ *
+ * @param[out] sorted_poa                Device buffer with sorted graph
+ * @param[out] distance_to_end           Device buffer to store computed node distances in graph
+ * @param[in] node_count                 Number of graph nodes
+ * @param[in] incoming_edge_count        Device buffer with number of incoming edges per node
+ * @param[in] incoming_edges             Device buffer with incoming edges per node
+ * @param[in] outgoing_edge_count        Device buffer with number of outgoing edges per node
+ * @param[in] local_outgoing_edge_count  Device scratch space for maintaining edge counts during topological sort
+ */
+template <typename SizeT>
+__device__ void distanceToHeadNode(SizeT* sorted_poa,
+                                   SizeT node_count,
+                                   uint16_t* incoming_edge_count,
+                                   uint16_t* local_incoming_edge_count,
+                                   SizeT* incoming_edges           = NULL,
+                                   uint16_t* incoming_edge_weights = NULL,
+                                   SizeT* distance_to_head_node0   = NULL)
+{
+
+    //
+    SizeT distance_to_head_node[20];
+
+    // Iterate through node IDs (since nodes are from 0
+    // through node_count -1, a simple loop works) and fill
+    // out the incoming edge count.
+    for (SizeT n = 0; n < node_count; n++)
+    {
+        local_incoming_edge_count[n] = incoming_edge_count[n];
+        // If we find a node ID has 0 incoming edges, set its distance to 0
+        if (local_incoming_edge_count[n] == 0)
+        {
+            distance_to_head_node[n] = 0;
+        }
+    }
+
+    // the following is to compute distance array used in adaptive banding, it works on a sorted graph
+    for (SizeT n = 0; n < node_count; ++n)
+    {
+        SizeT node = sorted_poa[n];
+        // To update distance to head node, loop through all successors and pick the one with heaviest edge
+        // then increment the distance of the selected successor node by one and assign it as distance of the current node
+        int16_t max_successor_weight = 0;
+        SizeT successor_distance     = -1;
+        SizeT successor_node         = 0;
+        for (uint16_t in_edge = 0; in_edge < incoming_edge_count[node]; ++in_edge)
+        {
+            if (max_successor_weight < incoming_edge_weights[node * CUDAPOA_MAX_NODE_EDGES + in_edge])
+            {
+                max_successor_weight = incoming_edge_weights[node * CUDAPOA_MAX_NODE_EDGES + in_edge];
+                successor_node       = incoming_edges[node * CUDAPOA_MAX_NODE_EDGES + in_edge];
+                successor_distance   = distance_to_head_node[successor_node];
+            }
+        }
+        //printf("> i %3d, sorted_i %3d, in_count %d, max_weight %3d, max_successor_node %3d, dist %3d \n", n, node, incoming_edge_count[node], max_successor_weight, successor_node, successor_distance+1);
+        distance_to_head_node[node] = successor_distance + 1;
+        printf("> n %3d, sorted_n %3d, distance %3d \n", n, node, successor_distance + 1);
+    }
+}
+
+} // namespace cudapoa
+
+} // namespace genomeworks
+
+} // namespace claraparabricks

--- a/cudapoa/src/cudapoa_adaptive_banding.cu
+++ b/cudapoa/src/cudapoa_adaptive_banding.cu
@@ -24,43 +24,38 @@ namespace cudapoa
 {
 
 /**
- * @brief Device function for computing outgoing path length of each node to the end of the POA graph.
+ * @brief Device function for computing length of path (with heaviest weight) of each node to the head of the POA graph.
+ *        The output of this kernel is used in adaptive banding to compute band-width per graph node
  *
- * @param[out] sorted_poa                Device buffer with sorted graph
- * @param[out] distance_to_end           Device buffer to store computed node distances in graph
+ * @param[in] sorted_poa                 Device buffer with sorted graph
  * @param[in] node_count                 Number of graph nodes
  * @param[in] incoming_edge_count        Device buffer with number of incoming edges per node
+ * @param[in] local_incoming_edge_count  Device scratch space for maintaining edge counts during distance computation
  * @param[in] incoming_edges             Device buffer with incoming edges per node
- * @param[in] outgoing_edge_count        Device buffer with number of outgoing edges per node
- * @param[in] local_outgoing_edge_count  Device scratch space for maintaining edge counts during topological sort
- */
+ * @param[in] incoming_edge_weights      Device buffer with weights of incoming edges
+ * @param[out] node_distance             Device buffer to store computed node distances in the graph
+*/
 template <typename SizeT>
 __device__ void distanceToHeadNode(SizeT* sorted_poa,
                                    SizeT node_count,
                                    uint16_t* incoming_edge_count,
                                    uint16_t* local_incoming_edge_count,
-                                   SizeT* incoming_edges           = NULL,
-                                   uint16_t* incoming_edge_weights = NULL,
-                                   SizeT* distance_to_head_node0   = NULL)
+                                   SizeT* incoming_edges,
+                                   uint16_t* incoming_edge_weights,
+                                   SizeT* node_distance)
 {
-
-    //
-    SizeT distance_to_head_node[20];
-
-    // Iterate through node IDs (since nodes are from 0
-    // through node_count -1, a simple loop works) and fill
-    // out the incoming edge count.
+    // iterate through node IDs and fill out the local incoming edge count
     for (SizeT n = 0; n < node_count; n++)
     {
         local_incoming_edge_count[n] = incoming_edge_count[n];
-        // If we find a node ID has 0 incoming edges, set its distance to 0
+        // if a node ID has 0 incoming edges, set its distance to 0
         if (local_incoming_edge_count[n] == 0)
         {
-            distance_to_head_node[n] = 0;
+            node_distance[n] = 0;
         }
     }
 
-    // the following is to compute distance array used in adaptive banding, it works on a sorted graph
+    // the following loop works on a sorted graph
     for (SizeT n = 0; n < node_count; ++n)
     {
         SizeT node = sorted_poa[n];
@@ -75,12 +70,11 @@ __device__ void distanceToHeadNode(SizeT* sorted_poa,
             {
                 max_successor_weight = incoming_edge_weights[node * CUDAPOA_MAX_NODE_EDGES + in_edge];
                 successor_node       = incoming_edges[node * CUDAPOA_MAX_NODE_EDGES + in_edge];
-                successor_distance   = distance_to_head_node[successor_node];
+                successor_distance   = node_distance[successor_node];
             }
         }
-        //printf("> i %3d, sorted_i %3d, in_count %d, max_weight %3d, max_successor_node %3d, dist %3d \n", n, node, incoming_edge_count[node], max_successor_weight, successor_node, successor_distance+1);
-        distance_to_head_node[node] = successor_distance + 1;
-        printf("> n %3d, sorted_n %3d, distance %3d \n", n, node, successor_distance + 1);
+        node_distance[node] = successor_distance + 1;
+        //printf("> n %3d, sorted_n %3d, distance %3d \n", n, node, successor_distance + 1);
     }
 }
 

--- a/cudapoa/src/cudapoa_kernels.cu
+++ b/cudapoa/src/cudapoa_kernels.cu
@@ -229,17 +229,17 @@ __global__ void generatePOAKernel(uint8_t* consensus_d,
                 warp_error   = true;
             }
 
-//            if (cuda_banded_alignment)
-//            {
-//                // compute R for abPOA
-//                distanceToHeadNode(sorted_poa,
-//                                   sequence_lengths[0],
-//                                   incoming_edge_count,
-//                                   sorted_poa_local_edge_count,
-//                                   incoming_edges,
-//                                   incoming_edge_weights,
-//                                   node_distance);
-//            }
+            //            if (cuda_banded_alignment)
+            //            {
+            //                // compute R for abPOA
+            //                distanceToHeadNode(sorted_poa,
+            //                                   sequence_lengths[0],
+            //                                   incoming_edge_count,
+            //                                   sorted_poa_local_edge_count,
+            //                                   incoming_edges,
+            //                                   incoming_edge_weights,
+            //                                   node_distance);
+            //            }
         }
 
         warp_error = __shfl_sync(FULL_MASK, warp_error, 0);

--- a/cudapoa/src/cudapoa_kernels.cu
+++ b/cudapoa/src/cudapoa_kernels.cu
@@ -83,6 +83,7 @@ __global__ void generatePOAKernel(uint8_t* consensus_d,
                                   uint16_t* outgoing_edge_w_d,
                                   SizeT* sorted_poa_d,
                                   SizeT* node_id_to_pos_d,
+                                  SizeT* node_distance_d,
                                   SizeT* node_alignments_d,
                                   uint16_t* node_alignment_count_d,
                                   uint16_t* sorted_poa_local_edge_count_d,
@@ -123,6 +124,7 @@ __global__ void generatePOAKernel(uint8_t* consensus_d,
     uint16_t* outgoing_edge_weights       = &outgoing_edge_w_d[window_idx * max_nodes_per_window * CUDAPOA_MAX_NODE_EDGES];
     SizeT* sorted_poa                     = &sorted_poa_d[window_idx * max_nodes_per_window];
     SizeT* node_id_to_pos                 = &node_id_to_pos_d[window_idx * max_nodes_per_window];
+    SizeT* node_distance                  = &node_distance_d[window_idx * max_nodes_per_window];
     SizeT* node_alignments                = &node_alignments_d[window_idx * max_nodes_per_window * CUDAPOA_MAX_NODE_ALIGNMENTS];
     uint16_t* node_alignment_count        = &node_alignment_count_d[window_idx * max_nodes_per_window];
     uint16_t* sorted_poa_local_edge_count = &sorted_poa_local_edge_count_d[window_idx * max_nodes_per_window];
@@ -227,13 +229,17 @@ __global__ void generatePOAKernel(uint8_t* consensus_d,
                 warp_error   = true;
             }
 
-            // compute R
-//            distanceToHeadNode(sorted_poa,
-//                               sequence_lengths[0],
-//                               incoming_edge_count,
-//                               sorted_poa_local_edge_count,
-//                               incoming_edges,
-//                               incoming_edge_weights);
+//            if (cuda_banded_alignment)
+//            {
+//                // compute R for abPOA
+//                distanceToHeadNode(sorted_poa,
+//                                   sequence_lengths[0],
+//                                   incoming_edge_count,
+//                                   sorted_poa_local_edge_count,
+//                                   incoming_edges,
+//                                   incoming_edge_weights,
+//                                   node_distance);
+//            }
         }
 
         warp_error = __shfl_sync(FULL_MASK, warp_error, 0);
@@ -411,6 +417,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
     uint16_t* outgoing_edge_w               = graph_details_d->outgoing_edge_weights;
     SizeT* sorted_poa                       = graph_details_d->sorted_poa;
     SizeT* node_id_to_pos                   = graph_details_d->sorted_poa_node_map;
+    SizeT* node_distance                    = graph_details_d->node_distance_to_head;
     uint16_t* sorted_poa_local_edge_count   = graph_details_d->sorted_poa_local_edge_count;
     int32_t* consensus_scores               = graph_details_d->consensus_scores;
     SizeT* consensus_predecessors           = graph_details_d->consensus_predecessors;
@@ -451,6 +458,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                  outgoing_edge_w,
                                                                                  sorted_poa,
                                                                                  node_id_to_pos,
+                                                                                 node_distance,
                                                                                  node_alignments,
                                                                                  node_alignment_count,
                                                                                  sorted_poa_local_edge_count,
@@ -515,6 +523,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                                  outgoing_edge_w,
                                                                                  sorted_poa,
                                                                                  node_id_to_pos,
+                                                                                 node_distance,
                                                                                  node_alignments,
                                                                                  node_alignment_count,
                                                                                  sorted_poa_local_edge_count,
@@ -586,6 +595,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                     outgoing_edge_w,
                                                                     sorted_poa,
                                                                     node_id_to_pos,
+                                                                    node_distance,
                                                                     node_alignments,
                                                                     node_alignment_count,
                                                                     sorted_poa_local_edge_count,
@@ -649,6 +659,7 @@ void generatePOAtemplated(genomeworks::cudapoa::OutputDetails* output_details_d,
                                                                     outgoing_edge_w,
                                                                     sorted_poa,
                                                                     node_id_to_pos,
+                                                                    node_distance,
                                                                     node_alignments,
                                                                     node_alignment_count,
                                                                     sorted_poa_local_edge_count,

--- a/cudapoa/src/cudapoa_kernels.cuh
+++ b/cudapoa/src/cudapoa_kernels.cuh
@@ -138,6 +138,9 @@ struct GraphDetails
     // position in the topologically sorted graph.
     SizeT* sorted_poa_node_map;
 
+    // Device buffer to store distance of each graph node to the head node(s)
+    SizeT* node_distance_to_head;
+
     // Device buffer used during topological sort to store incoming
     // edge counts for nodes.
     uint16_t* sorted_poa_local_edge_count;


### PR DESCRIPTION
- added kernel `distanceToHeadNode()` to compute length of heaviest path from each POA graph node to the head node.

- added storage space to store computed distance vector
________________________________________________________________

- note 1: <span style="color:blue"> in the original paper, R is computed as distance from the end node. In this version, R is computed as distance from start node. If needed, we can revise the algorithm. That would require updating outgoing edge weights.

- note 2: the kernel call from `generatePOAKernel()` has been commented for now, as the computed distance vector will be used in the adaptive-banded POA, which is yet to be completed.

- note 3: closed previous PR, since it included some unrelated changes to allow reading fasta files as input. That change will be addressed in a separate PR related to creating cudaPOA binary. 