### PR TITLE
WIP - [pygw] fix intermittent test bug

### DIFF
--- a/pygenomeworks/test/test_cudaaligner_bindings.py
+++ b/pygenomeworks/test/test_cudaaligner_bindings.py
@@ -16,6 +16,13 @@ from genomeworks.simulators.genomesim import PoissonGenomeSimulator
 from genomeworks.simulators.readsim import NoisyReadSimulator
 
 
+@pytest.fixture
+def get_stream():
+    stream = cuda.CudaStream()
+    yield stream
+    del stream
+
+
 @pytest.mark.gpu
 @pytest.mark.parametrize("query, target, cigar", [
     ("AAAAAAA", "TTTTTTT", "7M"),
@@ -24,11 +31,11 @@ from genomeworks.simulators.readsim import NoisyReadSimulator
     ("TGCA", "ATACGCT", "1I1M2I3M"),
     pytest.param("ACGT", "TCGA", "5M", marks=pytest.mark.xfail),
     ])
-def test_cudaaligner_simple_batch(query, target, cigar):
+def test_cudaaligner_simple_batch(query, target, cigar, get_stream):
     """Test valid calculation of alignments by checking cigar strings.
     """
     device = cuda.cuda_get_device()
-    stream = cuda.CudaStream()
+    stream = get_stream
     batch = CudaAlignerBatch(len(query), len(target), 1, alignment_type="global", stream=stream, device_id=device)
     batch.add_alignment(query, target)
     batch.align_all()


### PR DESCRIPTION
issue appears to be with how we were handling the cuda aligner tests in python. the cleanup wasn't correct, which was leading to out of order destruction in pytest. using pytest fixture ensures the objects are deleted properly after each test.

temporarily resolves intermittent bug in tests