### PR TITLE
[cudamapper] Skip index pair which cause OOM errors

### DIFF
--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -201,6 +201,7 @@ struct OverlapsAndCigars
 /// \param device_cache data will be loaded into cache within the function
 /// \param application_parameters
 /// \param overlaps_and_cigars_to_process overlaps and cigars are output here and the then consumed by another thread
+/// \param number_of_skipped_pairs_of_indices number of pairs of indices skipped due to OOM error, variable shared between all threads, each call increases the number by the number of skipped pairs
 /// \param cuda_stream
 void process_one_device_batch(const IndexBatch& device_batch,
                               IndexCacheDevice& device_cache,
@@ -283,7 +284,7 @@ void process_one_device_batch(const IndexBatch& device_batch,
 /// \param host_cache data will be loaded into cache within the function
 /// \param device_cache data will be loaded into cache within the function
 /// \param overlaps_and_cigars_to_process overlaps and cigars are output to this structure and the then consumed by another thread
-/// \param number_of_skipped_pairs_of_indices
+/// \param number_of_skipped_pairs_of_indices number of pairs of indices skipped due to OOM error, variable shared between all threads, each call increases the number by the number of skipped pairs
 /// \param cuda_stream
 void process_one_batch(const BatchOfIndices& batch,
                        const ApplicationParameters& application_parameters,


### PR DESCRIPTION
Some pairs of indices generate so much anchors that the application runs our of memory.
Application now skips such pairs and prints the number of skipped pairs so the user can decide if that number is acceptable or the application should be rerun with different parameters.

Closes #489 

Application does not print which pairs have been skipped as a PR for #490 will significantly reduce the number of overall pairs which actually get skipped. That PR will include actually printing skipped pairs of indices