### PR TITLE
[cudamapper] Add create_overlapper function to instantiate overlapper object

### DIFF
--- a/cudamapper/include/claraparabricks/genomeworks/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claraparabricks/genomeworks/cudamapper/overlapper.hpp
@@ -110,6 +110,13 @@ public:
                                     const io::FastaParser& target_parser,
                                     std::int32_t extension,
                                     float required_similarity);
+
+    /// \brief Creates a Overlapper object
+    /// \param allocator The device memory allocator to use for buffer allocations
+    /// \param cuda_stream CUDA stream on which the work is to be done. Device arrays are also associated with this stream and will not be freed at least until all work issued on this stream before calling their destructor is done
+    /// \return Instance of Overlapper
+    static std::unique_ptr<Overlapper> create_overlapper(DefaultDeviceAllocator allocator,
+                                                         const cudaStream_t cuda_stream = 0);
 };
 //}
 } // namespace cudamapper

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -37,7 +37,6 @@
 #include "application_parameters.hpp"
 #include "cudamapper_utils.hpp"
 #include "index_batcher.cuh"
-#include "overlapper_triggered.hpp"
 
 namespace claraparabricks
 {
@@ -239,14 +238,14 @@ void process_one_device_batch(const IndexBatch& device_batch,
                                                            cuda_stream);
 
                     std::vector<Overlap> overlaps;
-                    OverlapperTriggered overlapper(device_allocator,
-                                                   cuda_stream);
-                    overlapper.get_overlaps(overlaps,
-                                            matcher->anchors(),
-                                            application_parameters.min_residues,
-                                            application_parameters.min_overlap_len,
-                                            application_parameters.min_bases_per_residue,
-                                            application_parameters.min_overlap_fraction);
+                    auto overlapper = Overlapper::create_overlapper(device_allocator,
+                                                                    cuda_stream);
+                    overlapper->get_overlaps(overlaps,
+                                             matcher->anchors(),
+                                             application_parameters.min_residues,
+                                             application_parameters.min_overlap_len,
+                                             application_parameters.min_bases_per_residue,
+                                             application_parameters.min_overlap_fraction);
 
                     // free up memory taken by matcher
                     matcher.reset(nullptr);

--- a/cudamapper/src/overlapper.cpp
+++ b/cudamapper/src/overlapper.cpp
@@ -21,6 +21,7 @@
 #include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
 
 #include "cudamapper_utils.hpp"
+#include "overlapper_triggered.hpp"
 
 namespace
 {
@@ -369,6 +370,13 @@ void Overlapper::rescue_overlap_ends(std::vector<Overlap>& overlaps,
             reverse_overlap(overlap, static_cast<uint32_t>(target_sequence.length()));
         }
     }
+}
+
+std::unique_ptr<Overlapper> Overlapper::create_overlapper(DefaultDeviceAllocator allocator,
+                                                          const cudaStream_t cuda_stream)
+{
+    return std::make_unique<OverlapperTriggered>(allocator,
+                                                 cuda_stream);
 }
 
 } // namespace cudamapper


### PR DESCRIPTION
Expose instantiation of overlapper object through a `create_overlapper()` function in the public API and replace the Overlapper creation in main.cu with public API function call.

closes #509 