### PR TITLE
[cudaaligner] banded myers with fixed bandwidth and low memory requirements

### DIFF
--- a/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
@@ -1,0 +1,37 @@
+/*
+* Copyright 2019-2020 NVIDIA CORPORATION.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#pragma once
+
+#include <vector>
+#include <thrust/system/cuda/experimental/pinned_allocator.h>
+
+namespace claraparabricks
+{
+
+namespace genomeworks
+{
+
+/// \brief An vector using pinned host memory for fast asynchronous transfers to the GPU
+///
+/// It is a std::vector with a special allocator for pinned host memory.
+/// Please see C++ documentation for std::vector.
+/// \tparam T The object's type
+template <typename T>
+using pinned_host_vector = std::vector<T, thrust::system::cuda::experimental::pinned_allocator<T>>;
+
+} // namespace genomeworks
+} // namespace claraparabricks

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -82,7 +82,7 @@ public:
     virtual void reset() = 0;
 };
 
-/// \brief Created Aligner object
+/// \brief Created Aligner object - DEPRECATED API
 ///
 /// \param max_query_length Maximum length of query string
 /// \param max_target_length Maximum length of target string
@@ -95,7 +95,7 @@ public:
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, AlignmentType type, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id);
 
-/// \brief Created Aligner object
+/// \brief Created Aligner object - DEPRECATED API
 ///
 /// \param max_query_length Maximum length of query string
 /// \param max_target_length Maximum length of target string
@@ -108,7 +108,7 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, AlignmentType type, cudaStream_t stream, int32_t device_id, int64_t max_device_memory_allocator_caching_size = -1);
 
-/// \brief Created Aligner object - NEW API
+/// \brief Created Aligner object
 ///
 /// \param type Type of aligner to construct
 /// \param max_bandwidth Maximum bandwidth for the Ukkonen band
@@ -120,7 +120,7 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, DefaultDeviceAllocator allocator, int64_t max_device_memory);
 
-/// \brief Created Aligner object - NEW API
+/// \brief Created Aligner object
 ///
 /// \param type Type of aligner to construct
 /// \param max_bandwidth Maximum bandwidth for the Ukkonen band

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -108,6 +108,13 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, AlignmentType type, cudaStream_t stream, int32_t device_id, int64_t max_device_memory_allocator_caching_size = -1);
 
+/// \brief Returns an estimate for the memory requirements per alignment
+///
+/// \param max_query_length Maximum length of query string
+/// \param max_target_length Maximum length of target string
+/// \return Required memory in bytes
+int64_t calc_memory_requirement_per_alignment(int32_t max_query_length, int32_t max_target_length);
+
 /// \}
 } // namespace cudaaligner
 

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -108,13 +108,28 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, AlignmentType type, cudaStream_t stream, int32_t device_id, int64_t max_device_memory_allocator_caching_size = -1);
 
-/// \brief Returns an estimate for the memory requirements per alignment
+/// \brief Created Aligner object - NEW API
 ///
-/// \param max_query_length Maximum length of query string
-/// \param max_target_length Maximum length of target string
-/// \return Required memory in bytes
-int64_t calc_memory_requirement_per_alignment(int32_t max_query_length, int32_t max_target_length);
+/// \param type Type of aligner to construct
+/// \param max_bandwidth Maximum bandwidth for the Ukkonen band
+/// \param stream CUDA Stream used for GPU interaction of the object
+/// \param device_id GPU device ID to run all CUDA operations on
+/// \param allocator Allocator to use for internal device memory allocations
+/// \param max_device_memory Maximum amount of device memory to use from passed in allocator in bytes (-1 for all available memory)
+///
+/// \return Unique pointer to Aligner object
+std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, DefaultDeviceAllocator allocator, int64_t max_device_memory);
 
+/// \brief Created Aligner object - NEW API
+///
+/// \param type Type of aligner to construct
+/// \param max_bandwidth Maximum bandwidth for the Ukkonen band
+/// \param stream CUDA Stream used for GPU interaction of the object
+/// \param device_id GPU device ID to run all CUDA operations on
+/// \param max_device_memory Maximum amount of device memory used in bytes (-1 (default) for all available memory).
+///
+/// \return Unique pointer to Aligner object
+std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, int64_t max_device_memory = -1);
 /// \}
 } // namespace cudaaligner
 

--- a/cudaaligner/src/aligner.cpp
+++ b/cudaaligner/src/aligner.cpp
@@ -17,6 +17,7 @@
 #include <claraparabricks/genomeworks/cudaaligner/aligner.hpp>
 
 #include "aligner_global_hirschberg_myers.hpp"
+#include "aligner_global_myers_banded.hpp"
 
 namespace claraparabricks
 {
@@ -68,6 +69,12 @@ std::unique_ptr<Aligner> create_aligner(
 #endif
     return create_aligner(max_query_length, max_target_length, max_alignments, type, allocator, stream, device_id);
 }
+
+int64_t calc_memory_requirement_per_alignment(int32_t max_sequence_length, int32_t max_bandwidth)
+{
+    return AlignerGlobalMyersBanded::calc_memory_requirement_per_alignment(max_sequence_length, max_bandwidth);
+}
+
 } // namespace cudaaligner
 
 } // namespace genomeworks

--- a/cudaaligner/src/aligner.cpp
+++ b/cudaaligner/src/aligner.cpp
@@ -70,9 +70,51 @@ std::unique_ptr<Aligner> create_aligner(
     return create_aligner(max_query_length, max_target_length, max_alignments, type, allocator, stream, device_id);
 }
 
-int64_t calc_memory_requirement_per_alignment(int32_t max_sequence_length, int32_t max_bandwidth)
+std::unique_ptr<Aligner> create_aligner(
+    const AlignmentType type,
+    const int32_t max_bandwidth,
+    cudaStream_t stream,
+    const int32_t device_id,
+    DefaultDeviceAllocator allocator,
+    const int64_t max_device_memory)
 {
-    return AlignerGlobalMyersBanded::calc_memory_requirement_per_alignment(max_sequence_length, max_bandwidth);
+    if (type == AlignmentType::global_alignment)
+    {
+        return std::make_unique<AlignerGlobalMyersBanded>(max_device_memory, max_bandwidth, allocator, stream, device_id);
+    }
+    else
+    {
+        throw std::runtime_error("Aligner for specified type not implemented yet.");
+    }
+}
+
+std::unique_ptr<Aligner> create_aligner(
+    const AlignmentType type,
+    const int32_t max_bandwidth,
+    cudaStream_t stream,
+    const int32_t device_id,
+    int64_t max_device_memory)
+{
+    if (max_device_memory < -1)
+    {
+        throw std::invalid_argument("max_device_memory has to be either -1 (=all available GPU memory) or greater or equal than 0.");
+    }
+#ifdef GW_ENABLE_CACHING_ALLOCATOR
+    // uses CachingDeviceAllocator
+    if (max_device_memory == -1)
+    {
+        max_device_memory = claraparabricks::genomeworks::cudautils::find_largest_contiguous_device_memory_section();
+        if (max_device_memory == 0)
+        {
+            throw std::runtime_error("No memory available for caching");
+        }
+    }
+    claraparabricks::genomeworks::DefaultDeviceAllocator allocator(max_device_memory);
+#else
+    // uses CudaMallocAllocator
+    claraparabricks::genomeworks::DefaultDeviceAllocator allocator;
+#endif
+    return create_aligner(type, max_bandwidth, stream, device_id, allocator, -1);
 }
 
 } // namespace cudaaligner

--- a/cudaaligner/src/aligner_global.cpp
+++ b/cudaaligner/src/aligner_global.cpp
@@ -45,7 +45,7 @@ constexpr int32_t calc_max_result_length(int32_t max_query_length, int32_t max_t
     return ceiling_divide(max_length, alignment_bytes) * alignment_bytes;
 }
 
-}
+} // namespace
 
 AlignerGlobal::AlignerGlobal(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
     : max_query_length_(throw_on_negative(max_query_length, "max_query_length must be non-negative."))

--- a/cudaaligner/src/aligner_global.cpp
+++ b/cudaaligner/src/aligner_global.cpp
@@ -35,12 +35,16 @@ namespace genomeworks
 
 namespace cudaaligner
 {
+namespace
+{
 
 constexpr int32_t calc_max_result_length(int32_t max_query_length, int32_t max_target_length)
 {
     constexpr int32_t alignment_bytes = 4;
     const int32_t max_length          = max_query_length + max_target_length;
     return ceiling_divide(max_length, alignment_bytes) * alignment_bytes;
+}
+
 }
 
 AlignerGlobal::AlignerGlobal(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
@@ -184,9 +188,9 @@ StatusType AlignerGlobal::sync_alignments()
     for (int32_t i = 0; i < n_alignments; ++i)
     {
         al_state.clear();
-        assert(result_lengths_h_[i] < max_result_length);
+        assert(std::abs(result_lengths_h_[i]) < max_result_length);
         const int8_t* r_begin = results_h_.data() + i * max_result_length;
-        const int8_t* r_end   = r_begin + result_lengths_h_[i];
+        const int8_t* r_end   = r_begin + std::abs(result_lengths_h_[i]);
         std::transform(r_begin, r_end, std::back_inserter(al_state), [](int8_t x) { return static_cast<AlignmentState>(x); });
         std::reverse(begin(al_state), end(al_state));
         AlignmentImpl* alignment = dynamic_cast<AlignmentImpl*>(alignments_[i].get());

--- a/cudaaligner/src/aligner_global.hpp
+++ b/cudaaligner/src/aligner_global.hpp
@@ -22,8 +22,7 @@
 #include <claraparabricks/genomeworks/utils/allocator.hpp>
 #include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
 #include <claraparabricks/genomeworks/utils/device_buffer.hpp>
-
-#include <thrust/system/cuda/experimental/pinned_allocator.h>
+#include <claraparabricks/genomeworks/utils/pinned_host_vector.hpp>
 
 namespace claraparabricks
 {
@@ -70,9 +69,6 @@ public:
     }
 
 private:
-    template <typename T>
-    using pinned_host_vector = std::vector<T, thrust::system::cuda::experimental::pinned_allocator<T>>;
-
     virtual void run_alignment(int8_t* results_d, int32_t* result_lengths, int32_t max_result_length, const char* sequences_d, int32_t* sequence_lengths_d, int32_t* sequence_lengths_h, int32_t max_sequence_length, int32_t num_alignments, cudaStream_t stream) = 0;
 
     int32_t max_query_length_;

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -29,12 +29,44 @@ namespace genomeworks
 namespace cudaaligner
 {
 
+namespace
+{
+
+constexpr int32_t word_size                = sizeof(myers::WordType) * CHAR_BIT;
+
+int64_t compute_matrix_size_per_alignment(int32_t max_target_length, int32_t max_bandwidth)
+{
+    assert(max_bandwidth >= 0);
+    assert(max_target_length >= 0);
+    const int32_t query_size            = max_target_length;
+    const int32_t p                     = (max_bandwidth+1) / 2;
+    const int32_t band_width            = std::min(1 + 2 * p, query_size);
+    const int64_t n_words_band          = ceiling_divide(band_width, word_size);
+    return n_words_band * (static_cast<int64_t>(max_target_length) + 1);
+}
+
+} // namespace
+
+int64_t AlignerGlobalMyersBanded::calc_memory_requirement_per_alignment(int32_t max_sequence_length, int32_t max_bandwidth)
+{
+    constexpr int32_t alignment_bytes = 4;
+    const int32_t max_query_length = max_sequence_length;
+    const int32_t max_target_length = max_sequence_length;
+    const int32_t max_words_query = ceiling_divide(max_query_length, word_size);
+    const int64_t matrix_size_per_alignment = compute_matrix_size_per_alignment(max_target_length, max_bandwidth);
+    const int32_t max_result_length = ceiling_divide(max_query_length + max_target_length, alignment_bytes) * alignment_bytes;
+    return 2 * matrix_size_per_alignment * sizeof(myers::WordType) +
+        matrix_size_per_alignment * sizeof(int32_t) +
+        max_words_query * 4 * sizeof(myers::WordType) +
+        2 * max_result_length * sizeof(int8_t);
+}
+
 struct AlignerGlobalMyersBanded::Workspace
 {
-    Workspace(int32_t max_alignments, int32_t max_n_words, int32_t max_target_length, DefaultDeviceAllocator allocator, cudaStream_t stream)
-        : pvs(max_alignments, max_n_words * (max_target_length + 1), allocator, stream)
-        , mvs(max_alignments, max_n_words * (max_target_length + 1), allocator, stream)
-        , scores(max_alignments, max_n_words * (max_target_length + 1), allocator, stream)
+    Workspace(int32_t max_alignments, int32_t max_n_words, int64_t matrix_size_per_alignment, DefaultDeviceAllocator allocator, cudaStream_t stream)
+        : pvs(max_alignments, matrix_size_per_alignment, allocator, stream)
+        , mvs(max_alignments, matrix_size_per_alignment, allocator, stream)
+        , scores(max_alignments, matrix_size_per_alignment, allocator, stream)
         , query_patterns(max_alignments, max_n_words * 4, allocator, stream)
     {
     }
@@ -44,12 +76,19 @@ struct AlignerGlobalMyersBanded::Workspace
     batched_device_matrices<myers::WordType> query_patterns;
 };
 
-AlignerGlobalMyersBanded::AlignerGlobalMyersBanded(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
-    : AlignerGlobal(max_query_length, max_target_length, max_alignments, allocator, stream, device_id)
+AlignerGlobalMyersBanded::AlignerGlobalMyersBanded(int32_t max_sequence_length, int32_t max_bandwidth, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
+    : AlignerGlobal(max_sequence_length, max_sequence_length, max_alignments, allocator, stream, device_id)
     , workspace_()
+    , max_bandwidth_(max_bandwidth)
 {
+    if(max_bandwidth % (sizeof(myers::WordType)*CHAR_BIT) == 1)
+    {
+        throw std::runtime_error("Invalid max_bandwidth value. Please change it by +/-1.");
+    }
     scoped_device_switch dev(device_id);
-    workspace_ = std::make_unique<Workspace>(max_alignments, ceiling_divide<int32_t>(max_query_length, sizeof(myers::WordType)), max_target_length, allocator, stream);
+    const int32_t max_words_query           = ceiling_divide<int32_t>(max_sequence_length, word_size);
+    const int64_t matrix_size_per_alignment = compute_matrix_size_per_alignment(max_sequence_length, max_bandwidth_);
+    workspace_ = std::make_unique<Workspace>(max_alignments, max_words_query, matrix_size_per_alignment, allocator, stream);
 }
 
 AlignerGlobalMyersBanded::~AlignerGlobalMyersBanded()
@@ -63,7 +102,7 @@ void AlignerGlobalMyersBanded::run_alignment(int8_t* results_d, int32_t* result_
 {
     static_cast<void>(sequence_lengths_h);
     myers_banded_gpu(results_d, result_lengths_d, max_result_length,
-                     sequences_d, sequence_lengths_d, max_sequence_length, num_alignments,
+                     sequences_d, sequence_lengths_d, max_sequence_length, num_alignments, max_bandwidth_,
                      workspace_->pvs, workspace_->mvs, workspace_->scores, workspace_->query_patterns,
                      stream);
 }

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -23,6 +23,7 @@
 #include <claraparabricks/genomeworks/utils/cudautils.hpp>
 #include <claraparabricks/genomeworks/utils/genomeutils.hpp>
 #include <claraparabricks/genomeworks/utils/mathutils.hpp>
+#include <claraparabricks/genomeworks/utils/pinned_host_vector.hpp>
 
 namespace claraparabricks
 {
@@ -40,9 +41,6 @@ constexpr int32_t n_alignments_initial_parameter = 1000; // for initial allocati
 
 using myers::WordType;
 constexpr int32_t word_size = sizeof(myers::WordType) * CHAR_BIT;
-
-template <typename T>
-using pinned_host_vector = std::vector<T, thrust::system::cuda::experimental::pinned_allocator<T>>;
 
 int64_t compute_matrix_size_for_alignment(const int32_t query_size, const int32_t target_size, const int32_t max_bandwidth)
 {

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -17,7 +17,11 @@
 #include "aligner_global_myers_banded.hpp"
 #include "myers_gpu.cuh"
 #include "batched_device_matrices.cuh"
+#include "alignment_impl.hpp"
 
+#include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
+#include <claraparabricks/genomeworks/utils/cudautils.hpp>
+#include <claraparabricks/genomeworks/utils/genomeutils.hpp>
 #include <claraparabricks/genomeworks/utils/mathutils.hpp>
 
 namespace claraparabricks
@@ -32,63 +36,121 @@ namespace cudaaligner
 namespace
 {
 
-constexpr int32_t word_size                = sizeof(myers::WordType) * CHAR_BIT;
+constexpr int32_t n_alignments_initial_parameter = 1000; // for initial allocation - buffers will grow automatically if needed.
 
-int64_t compute_matrix_size_per_alignment(int32_t max_target_length, int32_t max_bandwidth)
+using myers::WordType;
+constexpr int32_t word_size = sizeof(myers::WordType) * CHAR_BIT;
+
+template <typename T>
+using pinned_host_vector = std::vector<T, thrust::system::cuda::experimental::pinned_allocator<T>>;
+
+int64_t compute_matrix_size_for_alignment(const int32_t query_size, const int32_t target_size, const int32_t max_bandwidth)
 {
     assert(max_bandwidth >= 0);
-    assert(max_target_length >= 0);
-    const int32_t query_size            = max_target_length;
-    const int32_t p                     = (max_bandwidth+1) / 2;
-    const int32_t band_width            = std::min(1 + 2 * p, query_size);
-    const int64_t n_words_band          = ceiling_divide(band_width, word_size);
-    return n_words_band * (static_cast<int64_t>(max_target_length) + 1);
+    assert(target_size >= 0);
+    const int32_t p            = (max_bandwidth + 1) / 2;
+    const int32_t bandwidth    = std::min(1 + 2 * p, query_size);
+    const int64_t n_words_band = ceiling_divide(bandwidth, word_size);
+    return n_words_band * (static_cast<int64_t>(target_size) + 1);
+}
+
+struct memory_distribution
+{
+    int64_t sequence_memory;
+    int64_t results_memory;
+    int64_t query_patterns_memory;
+    int64_t pmvs_matrix_memory;
+    int64_t score_matrix_memory;
+    int64_t remainder;
+};
+
+memory_distribution split_available_memory(const int64_t max_device_memory, const int32_t max_bandwidth)
+{
+    assert(max_device_memory >= 0);
+    assert(max_bandwidth >= 0);
+
+    // Memory requirements per alignment per base pair
+    const float mem_req_sequence       = sizeof(char);
+    const float mem_req_results        = 2 * sizeof(char);
+    const float mem_req_query_patterns = 4.f / word_size;
+    const float mem_req_pmvs_matrix    = (sizeof(WordType) * static_cast<float>(max_bandwidth)) / word_size;
+    const float mem_req_score_matrix   = (sizeof(int32_t) * static_cast<float>(max_bandwidth)) / word_size;
+
+    const float mem_req_total_per_bp = 2 * mem_req_sequence + mem_req_results + mem_req_query_patterns + 2 * mem_req_pmvs_matrix + mem_req_score_matrix;
+
+    const float fmax_device_memory = static_cast<float>(max_device_memory) * 0.95; // reserve 5% for misc
+
+    memory_distribution r;
+    r.sequence_memory       = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_sequence);
+    r.results_memory        = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_results);
+    r.query_patterns_memory = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_query_patterns);
+    r.pmvs_matrix_memory    = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_pmvs_matrix);
+    r.score_matrix_memory   = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_score_matrix);
+    r.remainder             = max_device_memory - (2 * r.sequence_memory + r.results_memory + r.query_patterns_memory + 2 * r.pmvs_matrix_memory + r.score_matrix_memory);
+    return r;
 }
 
 } // namespace
 
-int64_t AlignerGlobalMyersBanded::calc_memory_requirement_per_alignment(int32_t max_sequence_length, int32_t max_bandwidth)
+struct AlignerGlobalMyersBanded::InternalData
 {
-    constexpr int32_t alignment_bytes = 4;
-    const int32_t max_query_length = max_sequence_length;
-    const int32_t max_target_length = max_sequence_length;
-    const int32_t max_words_query = ceiling_divide(max_query_length, word_size);
-    const int64_t matrix_size_per_alignment = compute_matrix_size_per_alignment(max_target_length, max_bandwidth);
-    const int32_t max_result_length = ceiling_divide(max_query_length + max_target_length, alignment_bytes) * alignment_bytes;
-    return 2 * matrix_size_per_alignment * sizeof(myers::WordType) +
-        matrix_size_per_alignment * sizeof(int32_t) +
-        max_words_query * 4 * sizeof(myers::WordType) +
-        2 * max_result_length * sizeof(int8_t);
-}
-
-struct AlignerGlobalMyersBanded::Workspace
-{
-    Workspace(int32_t max_alignments, int32_t max_n_words, int64_t matrix_size_per_alignment, DefaultDeviceAllocator allocator, cudaStream_t stream)
-        : pvs(max_alignments, matrix_size_per_alignment, allocator, stream)
-        , mvs(max_alignments, matrix_size_per_alignment, allocator, stream)
-        , scores(max_alignments, matrix_size_per_alignment, allocator, stream)
-        , query_patterns(max_alignments, max_n_words * 4, allocator, stream)
+    InternalData(const memory_distribution mem, const int32_t n_alignments_initial, const DefaultDeviceAllocator& allocator, cudaStream_t stream)
+        : seq_h(2 * mem.sequence_memory / sizeof(char))
+        , seq_starts_h()
+        , results_h(mem.results_memory / sizeof(char))
+        , result_lengths_h()
+        , result_starts_h()
+        , seq_d(2 * mem.sequence_memory / sizeof(char), allocator, stream)
+        , seq_starts_d(2 * n_alignments_initial + 1, allocator, stream)
+        , results_d(mem.results_memory / sizeof(char), allocator, stream)
+        , result_starts_d(n_alignments_initial + 1, allocator, stream)
+        , result_lengths_d(n_alignments_initial, allocator, stream)
+        , pvs(mem.pmvs_matrix_memory / sizeof(WordType), allocator, stream)
+        , mvs(mem.pmvs_matrix_memory / sizeof(WordType), allocator, stream)
+        , scores(mem.score_matrix_memory / sizeof(int32_t), allocator, stream)
+        , query_patterns(mem.query_patterns_memory / sizeof(WordType), allocator, stream)
     {
+        seq_starts_h.reserve(2 * n_alignments_initial + 1);
+        result_starts_h.reserve(n_alignments_initial + 1);
+        result_lengths_h.reserve(n_alignments_initial);
     }
-    batched_device_matrices<myers::WordType> pvs;
-    batched_device_matrices<myers::WordType> mvs;
+
+    pinned_host_vector<char> seq_h;
+    pinned_host_vector<int64_t> seq_starts_h;
+    pinned_host_vector<int8_t> results_h;
+    pinned_host_vector<int32_t> result_lengths_h;
+    pinned_host_vector<int64_t> result_starts_h;
+    device_buffer<char> seq_d;
+    device_buffer<int64_t> seq_starts_d;
+    device_buffer<int8_t> results_d;
+    device_buffer<int64_t> result_starts_d;
+    device_buffer<int32_t> result_lengths_d;
+    batched_device_matrices<WordType> pvs;
+    batched_device_matrices<WordType> mvs;
     batched_device_matrices<int32_t> scores;
-    batched_device_matrices<myers::WordType> query_patterns;
+    batched_device_matrices<WordType> query_patterns;
 };
 
-AlignerGlobalMyersBanded::AlignerGlobalMyersBanded(int32_t max_sequence_length, int32_t max_bandwidth, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
-    : AlignerGlobal(max_sequence_length, max_sequence_length, max_alignments, allocator, stream, device_id)
-    , workspace_()
+AlignerGlobalMyersBanded::AlignerGlobalMyersBanded(int64_t max_device_memory, int32_t max_bandwidth, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id)
+    : data_()
+    , stream_(stream)
+    , device_id_(device_id)
     , max_bandwidth_(max_bandwidth)
+    , alignments_()
 {
-    if(max_bandwidth % (sizeof(myers::WordType)*CHAR_BIT) == 1)
+    if (max_bandwidth % (sizeof(WordType) * CHAR_BIT) == 1)
     {
-        throw std::runtime_error("Invalid max_bandwidth value. Please change it by +/-1.");
+        throw std::invalid_argument("Invalid max_bandwidth value. Please change it by +/-1.");
+    }
+    if (max_device_memory < 0)
+    {
+        max_device_memory = get_size_of_largest_free_memory_block(allocator);
     }
     scoped_device_switch dev(device_id);
-    const int32_t max_words_query           = ceiling_divide<int32_t>(max_sequence_length, word_size);
-    const int64_t matrix_size_per_alignment = compute_matrix_size_per_alignment(max_sequence_length, max_bandwidth_);
-    workspace_ = std::make_unique<Workspace>(max_alignments, max_words_query, matrix_size_per_alignment, allocator, stream);
+    const memory_distribution mem = split_available_memory(max_device_memory, max_bandwidth);
+    data_                         = std::make_unique<AlignerGlobalMyersBanded::InternalData>(mem, n_alignments_initial_parameter, allocator, stream_);
+    data_->seq_starts_h.push_back(0);
+    data_->result_starts_h.push_back(0);
 }
 
 AlignerGlobalMyersBanded::~AlignerGlobalMyersBanded()
@@ -96,15 +158,187 @@ AlignerGlobalMyersBanded::~AlignerGlobalMyersBanded()
     // Keep empty destructor to keep Workspace type incomplete in the .hpp file.
 }
 
-void AlignerGlobalMyersBanded::run_alignment(int8_t* results_d, int32_t* result_lengths_d, int32_t max_result_length,
-                                             const char* sequences_d, int32_t* sequence_lengths_d, int32_t* sequence_lengths_h, int32_t max_sequence_length,
-                                             int32_t num_alignments, cudaStream_t stream)
+StatusType AlignerGlobalMyersBanded::add_alignment(const char* query, int32_t query_length, const char* target, int32_t target_length, bool reverse_complement_query, bool reverse_complement_target)
 {
-    static_cast<void>(sequence_lengths_h);
-    myers_banded_gpu(results_d, result_lengths_d, max_result_length,
-                     sequences_d, sequence_lengths_d, max_sequence_length, num_alignments, max_bandwidth_,
-                     workspace_->pvs, workspace_->mvs, workspace_->scores, workspace_->query_patterns,
-                     stream);
+    throw_on_negative(query_length, "query_length should not be negative");
+    throw_on_negative(target_length, "target_length should not be negative");
+    if (query == nullptr || target == nullptr)
+        return StatusType::generic_error;
+
+    scoped_device_switch dev(device_id_);
+    auto& seq_h           = data_->seq_h;
+    auto& seq_starts_h    = data_->seq_starts_h;
+    auto& result_starts_h = data_->result_starts_h;
+
+    batched_device_matrices<WordType>& pvs            = data_->pvs;
+    batched_device_matrices<WordType>& mvs            = data_->mvs;
+    batched_device_matrices<int32_t>& scores          = data_->scores;
+    batched_device_matrices<WordType>& query_patterns = data_->query_patterns;
+
+    assert(!seq_starts_h.empty());
+    assert(!result_starts_h.empty());
+    assert(get_size(seq_h) == get_size(data_->seq_d));
+    assert(get_size(data_->results_h) == get_size(data_->results_d));
+
+    assert(pvs.remaining_free_matrix_elements() == scores.remaining_free_matrix_elements());
+    assert(mvs.remaining_free_matrix_elements() == scores.remaining_free_matrix_elements());
+    assert(pvs.number_of_matrices() == scores.number_of_matrices());
+    assert(mvs.number_of_matrices() == scores.number_of_matrices());
+    assert(query_patterns.number_of_matrices() == scores.number_of_matrices());
+
+    const int64_t matrix_size        = compute_matrix_size_for_alignment(query_length, target_length, max_bandwidth_);
+    const int32_t n_words_query      = ceiling_divide(query_length, word_size);
+    const int32_t query_pattern_size = n_words_query * 4;
+
+    if (matrix_size > scores.remaining_free_matrix_elements())
+    {
+        return StatusType::exceeded_max_alignments;
+    }
+    if (query_pattern_size > query_patterns.remaining_free_matrix_elements())
+    {
+        return StatusType::exceeded_max_alignments;
+    }
+    if (target_length + query_length > get_size<int64_t>(seq_h) - seq_starts_h.back() || target_length + query_length > get_size<int64_t>(data_->results_h) - result_starts_h.back())
+    {
+        return StatusType::exceeded_max_alignments;
+    }
+
+    // TODO handle reverse complements
+    assert(reverse_complement_query == false);
+    assert(reverse_complement_target == false);
+    assert(get_size(seq_starts_h) % 2 == 1);
+    const int64_t seq_start = seq_starts_h.back();
+    genomeutils::copy_sequence(query, query_length, seq_h.data() + seq_start, reverse_complement_query);
+    genomeutils::copy_sequence(target, target_length, seq_h.data() + seq_start + query_length, reverse_complement_target);
+    seq_starts_h.push_back(seq_start + query_length);
+    seq_starts_h.push_back(seq_start + query_length + target_length);
+    result_starts_h.push_back(result_starts_h.back() + query_length + target_length);
+
+    bool success = pvs.append_matrix(matrix_size);
+    success      = success && mvs.append_matrix(matrix_size);
+    success      = success && scores.append_matrix(matrix_size);
+    success      = success && query_patterns.append_matrix(query_pattern_size);
+
+    try
+    {
+        std::shared_ptr<AlignmentImpl> alignment = std::make_shared<AlignmentImpl>(query, query_length, target, target_length);
+        alignment->set_alignment_type(AlignmentType::global_alignment);
+        alignments_.push_back(alignment);
+    }
+    catch (...)
+    {
+        success = false;
+    }
+
+    if (!success)
+    {
+        // This should never trigger due to the size check before the append.
+        this->reset();
+        return StatusType::generic_error;
+    }
+
+    return StatusType::success;
+}
+
+StatusType AlignerGlobalMyersBanded::align_all()
+{
+    using cudautils::device_copy_n;
+    const auto n_alignments = get_size(alignments_);
+    if (n_alignments == 0)
+        return StatusType::success;
+
+    scoped_device_switch dev(device_id_);
+
+    data_->pvs.construct_device_matrices_async(stream_);
+    data_->mvs.construct_device_matrices_async(stream_);
+    data_->scores.construct_device_matrices_async(stream_);
+    data_->query_patterns.construct_device_matrices_async(stream_);
+
+    const auto& seq_h           = data_->seq_h;
+    const auto& seq_starts_h    = data_->seq_starts_h;
+    auto& results_h             = data_->results_h;
+    auto& result_lengths_h      = data_->result_lengths_h;
+    const auto& result_starts_h = data_->result_starts_h;
+
+    auto& seq_d            = data_->seq_d;
+    auto& seq_starts_d     = data_->seq_starts_d;
+    auto& results_d        = data_->results_d;
+    auto& result_starts_d  = data_->result_starts_d;
+    auto& result_lengths_d = data_->result_lengths_d;
+
+    assert(get_size(seq_starts_h) == 2 * n_alignments + 1);
+    assert(get_size(result_starts_h) == n_alignments + 1);
+    if (get_size(seq_starts_d) < 2 * n_alignments + 1)
+    {
+        seq_starts_d.clear_and_resize(2 * n_alignments + 1);
+    }
+    if (get_size(result_starts_d) < n_alignments + 1)
+    {
+        result_starts_d.clear_and_resize(n_alignments + 1);
+    }
+    if (get_size(result_lengths_d) < n_alignments)
+    {
+        result_lengths_d.clear_and_resize(n_alignments);
+    }
+    device_copy_n(seq_h.data(), seq_starts_h.back(), seq_d.data(), stream_);
+    device_copy_n(seq_starts_h.data(), 2 * n_alignments + 1, seq_starts_d.data(), stream_);
+    device_copy_n(result_starts_h.data(), n_alignments + 1, result_starts_d.data(), stream_);
+
+    myers_banded_gpu(results_d.data(), result_lengths_d.data(), result_starts_d.data(),
+                     seq_d.data(), seq_starts_d.data(), n_alignments, max_bandwidth_,
+                     data_->pvs, data_->mvs, data_->scores, data_->query_patterns,
+                     stream_);
+
+    result_lengths_h.clear();
+    result_lengths_h.resize(n_alignments);
+
+    device_copy_n(results_d.data(), result_starts_h.back(), results_h.data(), stream_);
+    device_copy_n(result_lengths_d.data(), n_alignments, result_lengths_h.data(), stream_);
+
+    return StatusType::success;
+}
+
+StatusType AlignerGlobalMyersBanded::sync_alignments()
+{
+    scoped_device_switch dev(device_id_);
+    GW_CU_CHECK_ERR(cudaStreamSynchronize(stream_));
+
+    const int32_t n_alignments = get_size<int32_t>(alignments_);
+    std::vector<AlignmentState> al_state;
+    for (int32_t i = 0; i < n_alignments; ++i)
+    {
+        al_state.clear();
+        const int8_t* r_begin = data_->results_h.data() + data_->result_starts_h[i];
+        const int8_t* r_end   = r_begin + std::abs(data_->result_lengths_h[i]);
+        std::transform(r_begin, r_end, std::back_inserter(al_state), [](int8_t x) { return static_cast<AlignmentState>(x); });
+        std::reverse(begin(al_state), end(al_state));
+        AlignmentImpl* alignment = dynamic_cast<AlignmentImpl*>(alignments_[i].get());
+        alignment->set_alignment(al_state);
+        alignment->set_status(StatusType::success);
+    }
+    reset_data();
+    return StatusType::success;
+}
+
+void AlignerGlobalMyersBanded::reset()
+{
+    reset_data();
+    alignments_.clear();
+}
+
+void AlignerGlobalMyersBanded::reset_data()
+{
+    data_->seq_starts_h.clear();
+    data_->result_lengths_h.clear();
+    data_->result_starts_h.clear();
+
+    data_->seq_starts_h.push_back(0);
+    data_->result_starts_h.push_back(0);
+
+    data_->pvs.clear();
+    data_->mvs.clear();
+    data_->scores.clear();
+    data_->query_patterns.clear();
 }
 
 } // namespace cudaaligner

--- a/cudaaligner/src/aligner_global_myers_banded.hpp
+++ b/cudaaligner/src/aligner_global_myers_banded.hpp
@@ -30,8 +30,10 @@ namespace cudaaligner
 class AlignerGlobalMyersBanded : public AlignerGlobal
 {
 public:
-    AlignerGlobalMyersBanded(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id);
+    AlignerGlobalMyersBanded(int32_t max_sequence_length, int32_t max_bandwidth, int32_t max_alignments, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id);
     virtual ~AlignerGlobalMyersBanded();
+
+    static int64_t calc_memory_requirement_per_alignment(int32_t max_sequence_length, int32_t max_bandwidth);
 
 private:
     struct Workspace;
@@ -41,6 +43,7 @@ private:
                                int32_t num_alignments, cudaStream_t stream) override;
 
     std::unique_ptr<Workspace> workspace_;
+    int32_t max_bandwidth_;
 };
 
 } // namespace cudaaligner

--- a/cudaaligner/src/batched_device_matrices.cuh
+++ b/cudaaligner/src/batched_device_matrices.cuh
@@ -20,7 +20,10 @@
 
 #include <claraparabricks/genomeworks/utils/cudautils.hpp>
 #include <claraparabricks/genomeworks/utils/limits.cuh>
+#include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
 #include <claraparabricks/genomeworks/utils/device_buffer.hpp>
+
+#include <thrust/system/cuda/experimental/pinned_allocator.h>
 
 #include <tuple>
 #include <cassert>
@@ -77,9 +80,9 @@ public:
     }
 
 private:
-    T* data_;
-    int32_t n_rows_;
-    int32_t n_cols_;
+    T* data_        = nullptr;
+    int32_t n_rows_ = 0;
+    int32_t n_cols_ = 0;
 };
 
 template <typename T>
@@ -135,34 +138,82 @@ public:
         friend class batched_device_matrices<T>;
     };
 
+    batched_device_matrices(int64_t max_elements, DefaultDeviceAllocator allocator, cudaStream_t stream)
+        : storage_(max_elements, allocator, stream)
+        , offsets_(allocator, stream)
+        , dev_(1, allocator, stream)
+        , offsets_host_(1, 0)
+    {
+    }
+
     batched_device_matrices(int32_t n_matrices, int32_t max_elements_per_matrix, DefaultDeviceAllocator allocator, cudaStream_t stream)
         : storage_(static_cast<size_t>(n_matrices) * static_cast<size_t>(max_elements_per_matrix), allocator, stream)
         , offsets_(n_matrices + 1, allocator, stream)
-        , n_matrices_(n_matrices)
+        , dev_(1, allocator, stream)
+        , offsets_host_(n_matrices + 1)
     {
         assert(n_matrices >= 0);
         assert(max_elements_per_matrix >= 0);
-        GW_CU_CHECK_ERR(cudaMalloc(reinterpret_cast<void**>(&dev_), sizeof(device_interface)));
         GW_CU_CHECK_ERR(cudaMemsetAsync(storage_.data(), 0, storage_.size() * sizeof(T), stream));
-        std::vector<ptrdiff_t> offsets(n_matrices + 1);
+
         for (int32_t i = 0; i < n_matrices + 1; ++i)
         {
-            offsets[i] = max_elements_per_matrix * i;
+            offsets_host_[i] = max_elements_per_matrix * i;
         }
-        cudautils::device_copy_n(offsets.data(), n_matrices + 1, offsets_.data(), stream);
-        device_interface tmp(storage_.data(), offsets_.data(), n_matrices_);
-        GW_CU_CHECK_ERR(cudaMemcpyAsync(dev_, &tmp, sizeof(device_interface), cudaMemcpyHostToDevice, stream));
-        GW_CU_CHECK_ERR(cudaStreamSynchronize(stream)); // sync because local vars will be destroyed.
+
+        construct_device_matrices_async(stream);
     }
 
-    ~batched_device_matrices()
-    {
-        GW_CU_ABORT_ON_ERR(cudaFree(dev_));
-    }
+    ~batched_device_matrices() = default;
+
+    batched_device_matrices(batched_device_matrices const&) = delete;
+    batched_device_matrices& operator=(batched_device_matrices const&) = delete;
+    batched_device_matrices(batched_device_matrices&&)                 = default;
+    batched_device_matrices& operator=(batched_device_matrices&&) = default;
 
     device_interface* get_device_interface()
     {
-        return dev_;
+        return dev_.data();
+    }
+
+    bool append_matrix(int32_t max_elements)
+    {
+        assert(offsets_host_.size() >= 1);
+        const ptrdiff_t begin = offsets_host_.back();
+        if (begin + max_elements > get_size(storage_))
+        {
+            return false;
+        }
+        offsets_host_.push_back(begin + max_elements);
+        return true;
+    }
+
+    int32_t number_of_matrices() const
+    {
+        assert(offsets_host_.size() >= 1);
+        return get_size<int32_t>(offsets_host_) - 1;
+    }
+
+    int64_t remaining_free_matrix_elements() const
+    {
+        assert(offsets_host_.size() >= 1);
+        return get_size<int64_t>(storage_) - offsets_host_.back();
+    }
+
+    void clear()
+    {
+        offsets_host_.clear();
+        offsets_host_.push_back(0);
+    }
+
+    void construct_device_matrices_async(cudaStream_t stream)
+    {
+        assert(offsets_host_.size() >= 1);
+        offsets_.clear_and_resize(offsets_host_.size());
+        dev_interface_host_.clear();
+        dev_interface_host_.emplace_back(storage_.data(), offsets_.data(), get_size<int32_t>(offsets_host_) - 1);
+        cudautils::device_copy_n(offsets_host_.data(), offsets_host_.size(), offsets_.data(), stream);
+        cudautils::device_copy_n(dev_interface_host_.data(), 1, dev_.data(), stream);
     }
 
     matrix<T> get_matrix(int32_t id, int32_t n_rows, int32_t n_cols, cudaStream_t stream)
@@ -171,25 +222,26 @@ public:
         assert(n_rows >= 0);
         assert(n_cols >= 0);
 
-        if (id >= n_matrices_)
+        if (id >= get_size(offsets_) - 1)
             throw std::runtime_error("Requested id is out of bounds.");
 
-        std::array<ptrdiff_t, 2> offsets;
-        cudautils::device_copy_n(offsets_.data() + id, 2, offsets.data(), stream);
         matrix<T> m(n_rows, n_cols);
-        GW_CU_CHECK_ERR(cudaStreamSynchronize(stream));
-        if (n_rows * n_cols > offsets[1] - offsets[0])
+        if (n_rows * n_cols > offsets_host_[id + 1] - offsets_host_[id])
             throw std::runtime_error("Requested matrix size is larger than allocated memory on device.");
-        cudautils::device_copy_n(storage_.data() + offsets[0], n_rows * n_cols, m.data(), stream);
+        cudautils::device_copy_n(storage_.data() + offsets_host_[id], n_rows * n_cols, m.data(), stream);
         GW_CU_CHECK_ERR(cudaStreamSynchronize(stream));
         return m;
     }
 
 private:
+    template <typename U>
+    using pinned_host_vector = std::vector<U, thrust::system::cuda::experimental::pinned_allocator<U>>;
+
     device_buffer<T> storage_;
     device_buffer<ptrdiff_t> offsets_;
-    device_interface* dev_ = nullptr;
-    int32_t n_matrices_;
+    device_buffer<device_interface> dev_;
+    pinned_host_vector<ptrdiff_t> offsets_host_;
+    pinned_host_vector<device_interface> dev_interface_host_; // just to provide truly async copies
 };
 
 } // namespace cudaaligner

--- a/cudaaligner/src/batched_device_matrices.cuh
+++ b/cudaaligner/src/batched_device_matrices.cuh
@@ -22,8 +22,7 @@
 #include <claraparabricks/genomeworks/utils/limits.cuh>
 #include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
 #include <claraparabricks/genomeworks/utils/device_buffer.hpp>
-
-#include <thrust/system/cuda/experimental/pinned_allocator.h>
+#include <claraparabricks/genomeworks/utils/pinned_host_vector.hpp>
 
 #include <tuple>
 #include <cassert>
@@ -238,9 +237,6 @@ public:
     }
 
 private:
-    template <typename U>
-    using pinned_host_vector = std::vector<U, thrust::system::cuda::experimental::pinned_allocator<U>>;
-
     device_buffer<T> storage_;
     device_buffer<ptrdiff_t> offsets_;
     device_buffer<device_interface> dev_;

--- a/cudaaligner/src/batched_device_matrices.cuh
+++ b/cudaaligner/src/batched_device_matrices.cuh
@@ -47,6 +47,10 @@ template <typename T>
 class device_matrix_view
 {
 public:
+    __device__ device_matrix_view()
+    {
+    }
+
     __device__ device_matrix_view(T* storage, int32_t n_rows, int32_t n_cols)
         : data_(storage)
         , n_rows_(n_rows)

--- a/cudaaligner/src/hirschberg_myers_gpu.cu
+++ b/cudaaligner/src/hirschberg_myers_gpu.cu
@@ -596,8 +596,8 @@ __device__ void hirschberg_myers(
     warp_shared_stack<query_target_range> stack(stack_buffer_begin, stack_buffer_end);
     stack.push({query_begin_absolute, query_end_absolute, target_begin_absolute, target_end_absolute});
 
-    assert(pvi->get_max_elements_per_matrix() == mvi->get_max_elements_per_matrix());
-    assert(scorei->get_max_elements_per_matrix() >= pvi->get_max_elements_per_matrix());
+    assert(pvi->get_max_elements_per_matrix(alignment_idx) == mvi->get_max_elements_per_matrix(alignment_idx));
+    assert(scorei->get_max_elements_per_matrix(alignment_idx) >= pvi->get_max_elements_per_matrix(alignment_idx));
 
     bool success   = true;
     int32_t length = 0;
@@ -624,7 +624,7 @@ __device__ void hirschberg_myers(
             if (e.query_end - e.query_begin < full_myers_threshold && e.query_end != e.query_begin)
             {
                 const int32_t n_words = ceiling_divide<int32_t>(e.query_end - e.query_begin, word_size);
-                if ((e.target_end - e.target_begin + 1) * n_words <= pvi->get_max_elements_per_matrix())
+                if ((e.target_end - e.target_begin + 1) * n_words <= pvi->get_max_elements_per_matrix(alignment_idx))
                 {
                     hirschberg_myers_compute_path(path, &length, pvi, mvi, scorei, query_patterns, e.target_begin, e.target_end, e.query_begin, e.query_end, query_begin_absolute, alignment_idx);
                     continue;

--- a/cudaaligner/src/myers_gpu.cu
+++ b/cudaaligner/src/myers_gpu.cu
@@ -682,6 +682,10 @@ myers_compute_scores_edit_dist_banded(
 
     assert(target_size > 0);
     assert(query_size > 0);
+    assert(band_width > 0);
+    assert(n_words_band > 0);
+    assert(p >= 0);
+    assert(alignment_idx >= 0);
 
     assert(pv.num_rows() == n_words_band);
     assert(mv.num_rows() == n_words_band);
@@ -742,8 +746,9 @@ myers_compute_scores_edit_dist_banded(
     }
     else
     {
-        diagonal_begin = query_size < target_size ? target_size - query_size + p + 2 : p + 2;
-        diagonal_end   = query_size < target_size ? query_size - p + 1 : query_size - (query_size - target_size) - p + 1;
+        const int32_t symmetric_band = (band_width - min(1 + 2 * p + abs(target_size - query_size), query_size) == 0) ? 1 : 0;
+        diagonal_begin = query_size < target_size ? target_size - query_size + p + 2 : p + 2 + (1 - symmetric_band);
+        diagonal_end   = query_size < target_size ? query_size - p + symmetric_band: query_size - (query_size - target_size) - p + 1;
 
         myers_compute_scores_horizontal_band_impl(pv, mv, score, query_patterns, target_begin, query_begin, target_size, 1, diagonal_begin, band_width, n_words_band, 0);
         myers_compute_scores_diagonal_band_impl(pv, mv, score, query_patterns, target_begin, query_begin, target_size, diagonal_begin, diagonal_end, band_width, n_words_band, 0);
@@ -755,6 +760,7 @@ __global__ void myers_banded_kernel(
     int8_t* paths_base,
     int32_t* path_lengths,
     const int32_t max_path_length,
+    const int32_t max_bandwidth,
     batched_device_matrices<WordType>::device_interface* pvi,
     batched_device_matrices<WordType>::device_interface* mvi,
     batched_device_matrices<int32_t>::device_interface* scorei,
@@ -766,6 +772,7 @@ __global__ void myers_banded_kernel(
     assert(warpSize == warp_size);
     assert(threadIdx.x < warp_size);
     assert(blockIdx.x == 0);
+    assert(max_bandwidth % word_size != 1); // we need at least two bits in the last word
 
     const int32_t alignment_idx = blockIdx.y * blockDim.y + threadIdx.y;
     if (alignment_idx >= n_alignments)
@@ -776,6 +783,14 @@ __global__ void myers_banded_kernel(
     const char* const target  = sequences_d + (2 * alignment_idx + 1) * max_sequence_length;
     const int32_t n_words     = (query_size + word_size - 1) / word_size;
     int8_t* path              = paths_base + alignment_idx * static_cast<ptrdiff_t>(max_path_length);
+    if(max_bandwidth - 1 < abs(target_size - query_size))
+    {
+        if(threadIdx.x == 0)
+        {
+            path_lengths[alignment_idx] = 0;
+        }
+        return;
+    }
 
     device_matrix_view<WordType> query_pattern = query_patternsi->get_matrix_view(alignment_idx, n_words, 4);
 
@@ -796,35 +811,57 @@ __global__ void myers_banded_kernel(
     // If the computed distance is smaller accept and compute the backtrace/path,
     // otherwise retry with a larger guess (i.e. and larger band).
     int32_t max_distance_estimate = max(1, abs(target_size - query_size) + min(target_size, query_size) / initial_distance_guess_factor);
+    device_matrix_view<WordType> pv;
+    device_matrix_view<WordType> mv;
+    device_matrix_view<int32_t> score;
+    int32_t diagonal_begin = -1;
+    int32_t diagonal_end   = -1;
+    int32_t band_width = 0;
     while (1)
     {
-        int32_t p          = min3(target_size, query_size, (max_distance_estimate - abs(target_size - query_size)) / 2);
-        int32_t band_width = min(1 + 2 * p + abs(target_size - query_size), query_size);
-        if (band_width % word_size == 1 && band_width != query_size) // we need at least two bits in the last word
+        int32_t p              = min3(target_size, query_size, (max_distance_estimate - abs(target_size - query_size)) / 2);
+        int32_t band_width_new = min(1 + 2 * p + abs(target_size - query_size), query_size);
+        if (band_width_new % word_size == 1 && band_width_new != query_size) // we need at least two bits in the last word
         {
             p += 1;
-            band_width = min(1 + 2 * p + abs(target_size - query_size), query_size);
+            band_width_new = min(1 + 2 * p + abs(target_size - query_size), query_size);
         }
-        const int32_t n_words_band = ceiling_divide(band_width, word_size);
-
-        device_matrix_view<WordType> pv   = pvi->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
-        device_matrix_view<WordType> mv   = mvi->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
-        device_matrix_view<int32_t> score = scorei->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
-        int32_t diagonal_begin            = -1;
-        int32_t diagonal_end              = -1;
+        if(band_width_new > max_bandwidth)
+        {
+            band_width_new = max_bandwidth;
+            p = (band_width_new - 1 - abs(target_size - query_size)) / 2;
+        }
+        const int32_t n_words_band = ceiling_divide(band_width_new, word_size);
+        if (static_cast<int64_t>(n_words_band) * static_cast<int64_t>(target_size + 1) > pvi->get_max_elements_per_matrix(alignment_idx))
+        {
+            band_width = -band_width;
+            break;
+        }
+        band_width = band_width_new;
+        pv   = pvi->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
+        mv   = mvi->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
+        score = scorei->get_matrix_view(alignment_idx, n_words_band, target_size + 1);
+        diagonal_begin = -1;
+        diagonal_end   = -1;
         myers_compute_scores_edit_dist_banded(diagonal_begin, diagonal_end, pv, mv, score, query_pattern, target, query, target_size, query_size, band_width, n_words_band, p, alignment_idx);
         __syncwarp();
         const int32_t cur_edit_distance = score(n_words_band - 1, target_size);
-        if (cur_edit_distance <= max_distance_estimate || band_width == query_size)
+        if (cur_edit_distance <= max_distance_estimate || band_width == query_size || band_width == max_bandwidth)
         {
-            if (threadIdx.x == 0)
-            {
-                const int32_t path_length   = myers_backtrace_banded(path, pv, mv, score, diagonal_begin, diagonal_end, band_width, target_size, query_size);
-                path_lengths[alignment_idx] = path_length;
-            }
             break;
         }
         max_distance_estimate *= 2;
+    }
+    if (threadIdx.x == 0)
+    {
+        int32_t path_length = 0;
+        if(band_width != 0)
+        {
+            path_length = band_width > 0 ? 1 : -1;
+            band_width = abs(band_width);
+            path_length *= myers_backtrace_banded(path, pv, mv, score, diagonal_begin, diagonal_end, band_width, target_size, query_size);
+        }
+        path_lengths[alignment_idx] = path_length;
     }
 }
 
@@ -955,6 +992,7 @@ void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path
                       int32_t const* sequence_lengths_d,
                       int32_t max_sequence_length,
                       int32_t n_alignments,
+                      int32_t max_bandwidth,
                       batched_device_matrices<myers::WordType>& pv,
                       batched_device_matrices<myers::WordType>& mv,
                       batched_device_matrices<int32_t>& score,
@@ -963,7 +1001,7 @@ void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path
 {
     const dim3 threads(warp_size, 1, 1);
     const dim3 blocks(1, ceiling_divide<int32_t>(n_alignments, threads.y), 1);
-    myers::myers_banded_kernel<<<blocks, threads, 0, stream>>>(paths_d, path_lengths_d, max_path_length, pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), query_patterns.get_device_interface(), sequences_d, sequence_lengths_d, max_sequence_length, n_alignments);
+    myers::myers_banded_kernel<<<blocks, threads, 0, stream>>>(paths_d, path_lengths_d, max_path_length, max_bandwidth, pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), query_patterns.get_device_interface(), sequences_d, sequence_lengths_d, max_sequence_length, n_alignments);
 }
 
 } // namespace cudaaligner

--- a/cudaaligner/src/myers_gpu.cuh
+++ b/cudaaligner/src/myers_gpu.cuh
@@ -55,6 +55,7 @@ void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path
                       int32_t const* sequence_lengths_d,
                       int32_t max_sequence_length,
                       int32_t n_alignments,
+                      int32_t max_bandwidth,
                       batched_device_matrices<myers::WordType>& pv,
                       batched_device_matrices<myers::WordType>& mv,
                       batched_device_matrices<int32_t>& score,

--- a/cudaaligner/src/myers_gpu.cuh
+++ b/cudaaligner/src/myers_gpu.cuh
@@ -50,10 +50,9 @@ void myers_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length
                batched_device_matrices<myers::WordType>& query_patterns,
                cudaStream_t stream);
 
-void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length,
+void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
                       char const* sequences_d,
-                      int32_t const* sequence_lengths_d,
-                      int32_t max_sequence_length,
+                      int64_t const* sequence_starts_d,
                       int32_t n_alignments,
                       int32_t max_bandwidth,
                       batched_device_matrices<myers::WordType>& pv,

--- a/cudaaligner/tests/CMakeLists.txt
+++ b/cudaaligner/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     Test_Misc.cpp
     Test_AlignmentImpl.cpp
     Test_AlignerGlobal.cpp
+    Test_ApproximateBandedMyers.cpp
     Test_MyersAlgorithm.cu
     Test_HirschbergMyers.cu
     Test_NeedlemanWunschImplementation.cpp

--- a/cudaaligner/tests/Test_AlignerGlobal.cpp
+++ b/cudaaligner/tests/Test_AlignerGlobal.cpp
@@ -233,9 +233,8 @@ TEST_P(TestAlignerGlobal, TestAlignmentKernel)
                                                          0);
         break;
     case AlignmentAlgorithm::MyersBanded:
-        aligner = std::make_unique<AlignerGlobalMyersBanded>(max_string_size,
-                                                             max_string_size,
-                                                             param.inputs.size(),
+        aligner = std::make_unique<AlignerGlobalMyersBanded>(-1,
+                                                             1024,
                                                              allocator,
                                                              nullptr,
                                                              0);

--- a/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
+++ b/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
@@ -1,0 +1,102 @@
+/*
+* Copyright 2019-2020 NVIDIA CORPORATION.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "../src/aligner_global_myers_banded.hpp"
+#include <claraparabricks/genomeworks/cudaaligner/alignment.hpp>
+#include <claraparabricks/genomeworks/utils/signed_integer_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <limits>
+
+namespace
+{
+
+constexpr int32_t word_size = 32;
+int32_t get_max_sequence_length(std::vector<std::pair<std::string, std::string>> const& inputs)
+{
+    using claraparabricks::genomeworks::get_size;
+    int64_t max_string_size = 0;
+    for (auto const& pair : inputs)
+    {
+        max_string_size = std::max(max_string_size, get_size(pair.first));
+        max_string_size = std::max(max_string_size, get_size(pair.second));
+    }
+    return static_cast<int32_t>(max_string_size);
+}
+
+struct TestCase
+{
+    std::string query;
+    std::string target;
+};
+
+std::vector<TestCase> create_band_test_cases()
+{
+    std::vector<TestCase> data;
+    data.push_back({"AGGGCGAATATCGCCTCCCGCATTAAGCTGTACCTTCCAGCCCCGCCGGTAATTCCAGCCGGTTGAAGCCACGTCTGCCACGGCACAATGTTTTCGCTTTGCCCGGTGACGGATTTAATCCACCACAG", "AGGGCGAATATCGCCTCCGCATTAAACTGTACTTCCCAGCCCCGCCAGTATTCCAGCGGGTTGAAGCCGCGTCTGCCACAGCGCAATGTTTTCTTTGCCCACGGTGACCGGTTTAGTCACTACAGTTGC"});
+    return data;
+}
+
+class TestApproximateBandedMyers : public ::testing::TestWithParam<TestCase>
+{
+};
+
+} // namespace
+
+TEST_P(TestApproximateBandedMyers, EditDistanceGrowsWithBand)
+{
+    using namespace claraparabricks::genomeworks::cudaaligner;
+    using namespace claraparabricks::genomeworks;
+
+    TestCase t = GetParam();
+
+    DefaultDeviceAllocator allocator = create_default_device_allocator();
+
+    const int32_t max_string_size = std::max(get_size<int32_t>(t.query), get_size<int32_t>(t.target));
+
+    int32_t last_edit_distance = std::numeric_limits<int32_t>::max();
+    int32_t last_bw = -1;
+    for (int32_t max_bw = 2; max_bw < 2048; ++max_bw)
+    {
+        if (max_bw % word_size == 1)
+            continue; // not supported
+        std::unique_ptr<Aligner> aligner = std::make_unique<AlignerGlobalMyersBanded>(max_string_size,
+                                                                                      max_bw,
+                                                                                      1,
+                                                                                      allocator,
+                                                                                      nullptr,
+                                                                                      0);
+
+        ASSERT_EQ(StatusType::success, aligner->add_alignment(t.query.c_str(), t.query.length(),
+                                                              t.target.c_str(), t.target.length()))
+            << "Could not add alignment to aligner";
+        aligner->align_all();
+        aligner->sync_alignments();
+        const std::vector<std::shared_ptr<Alignment>>& alignments = aligner->get_alignments();
+        ASSERT_EQ(get_size(alignments), 1);
+        std::vector<AlignmentState> operations = alignments[0]->get_alignment();
+        if(!operations.empty())
+        {
+            int32_t edit_distance = std::count_if(begin(operations), end(operations), [](AlignmentState x) { return x != AlignmentState::match; });
+            ASSERT_LE(edit_distance, last_edit_distance) << "for max bandwidth = " << max_bw << " vs. max bandwidth = " << last_bw;
+            last_edit_distance = edit_distance;
+            last_bw = max_bw;
+        }
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(TestApproximateBandedMyersInstance, TestApproximateBandedMyers, ::testing::ValuesIn(create_band_test_cases()));

--- a/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
+++ b/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
@@ -69,8 +69,9 @@ TEST_P(TestApproximateBandedMyers, EditDistanceGrowsWithBand)
     const int32_t max_string_size = std::max(get_size<int32_t>(t.query), get_size<int32_t>(t.target));
 
     int32_t last_edit_distance = std::numeric_limits<int32_t>::max();
-    int32_t last_bw = -1;
-    for (int32_t max_bw = 2; max_bw < 2048; ++max_bw)
+    int32_t last_bw            = -1;
+    std::vector<int32_t> bandwidths = {2, 4, 16, 31, 32, 34, 63, 64, 66, 255, 256, 258, 1023, 1024, 1026, 2048};
+    for(const int32_t max_bw : bandwidths)
     {
         if (max_bw % word_size == 1)
             continue; // not supported
@@ -89,12 +90,12 @@ TEST_P(TestApproximateBandedMyers, EditDistanceGrowsWithBand)
         const std::vector<std::shared_ptr<Alignment>>& alignments = aligner->get_alignments();
         ASSERT_EQ(get_size(alignments), 1);
         std::vector<AlignmentState> operations = alignments[0]->get_alignment();
-        if(!operations.empty())
+        if (!operations.empty())
         {
             int32_t edit_distance = std::count_if(begin(operations), end(operations), [](AlignmentState x) { return x != AlignmentState::match; });
             ASSERT_LE(edit_distance, last_edit_distance) << "for max bandwidth = " << max_bw << " vs. max bandwidth = " << last_bw;
             last_edit_distance = edit_distance;
-            last_bw = max_bw;
+            last_bw            = max_bw;
         }
     }
 };

--- a/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
+++ b/cudaaligner/tests/Test_ApproximateBandedMyers.cpp
@@ -68,16 +68,15 @@ TEST_P(TestApproximateBandedMyers, EditDistanceGrowsWithBand)
 
     const int32_t max_string_size = std::max(get_size<int32_t>(t.query), get_size<int32_t>(t.target));
 
-    int32_t last_edit_distance = std::numeric_limits<int32_t>::max();
-    int32_t last_bw            = -1;
+    int32_t last_edit_distance      = std::numeric_limits<int32_t>::max();
+    int32_t last_bw                 = -1;
     std::vector<int32_t> bandwidths = {2, 4, 16, 31, 32, 34, 63, 64, 66, 255, 256, 258, 1023, 1024, 1026, 2048};
-    for(const int32_t max_bw : bandwidths)
+    for (const int32_t max_bw : bandwidths)
     {
         if (max_bw % word_size == 1)
             continue; // not supported
-        std::unique_ptr<Aligner> aligner = std::make_unique<AlignerGlobalMyersBanded>(max_string_size,
+        std::unique_ptr<Aligner> aligner = std::make_unique<AlignerGlobalMyersBanded>(-1,
                                                                                       max_bw,
-                                                                                      1,
                                                                                       allocator,
                                                                                       nullptr,
                                                                                       0);


### PR DESCRIPTION
* Banded Myers takes an upper bound for the bandwidth now
* Banded Myers has a dynamic memory structure now - it doesn't allocate buffers of a fixed size for an alignment (based on the max_query_length and max_target_length given at construction) anymore.
* Added a new API to create a cudaaligner with a fixed bandwidth
* batched_device_matrices can accommodate matrices of different sizes now
