### PR TITLE
[hotfix][sdk] update cmake structure

### DIFF
--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -56,7 +56,7 @@ function(gw_enable_formatting_targets)
         set(format_check_list "")
 
         foreach(source IN LISTS FOLDER_FORMAT_SOURCES)
-            file(RELATIVE_PATH RELATIVE_PATH ${CMAKE_SOURCE_DIR} ${source})
+            file(RELATIVE_PATH RELATIVE_PATH ${PROJECT_SOURCE_DIR} ${source})
 
             # Apply formatting
             get_filename_component(SYMBOL_BASE_DIR ${RELATIVE_PATH} DIRECTORY)

--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -19,7 +19,7 @@
 macro (GitVersion)
     execute_process(COMMAND
         git describe --tag --dirty
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         OUTPUT_VARIABLE CLARA_PARABRICKS_GENOMEWORKS_VERSION
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/common/base/CMakeLists.txt
+++ b/common/base/CMakeLists.txt
@@ -16,47 +16,47 @@
 
 
 
-project(gwbase)
+set(MODULE_NAME gwbase)
 
 find_package(CUDA 9.0 QUIET REQUIRED)
 
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++14")
-message(STATUS "nvcc flags for ${PROJECT_NAME}: ${CUDA_NVCC_FLAGS}")
+message(STATUS "nvcc flags for ${MODULE_NAME}: ${CUDA_NVCC_FLAGS}")
 
 get_property(gw_library_type GLOBAL PROPERTY gw_library_type)
-add_library(${PROJECT_NAME} ${gw_library_type}
+add_library(${MODULE_NAME} ${gw_library_type}
         src/cudautils.cpp
         src/logging.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC spdlog ${CUDA_LIBRARIES})
+target_link_libraries(${MODULE_NAME} PUBLIC spdlog ${CUDA_LIBRARIES})
 
 if (gw_profiling)
     find_library(NVTX_LIBRARY nvToolsExt HINTS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC -DGW_PROFILING)
-    target_link_libraries(${PROJECT_NAME} PUBLIC ${NVTX_LIBRARY})
+    target_compile_definitions(${MODULE_NAME} PUBLIC -DGW_PROFILING)
+    target_link_libraries(${MODULE_NAME} PUBLIC ${NVTX_LIBRARY})
 endif()
 
 if (gw_device_synchronize_kernels)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC GW_DEVICE_SYNCHRONIZE)
+    target_compile_definitions(${MODULE_NAME} PUBLIC GW_DEVICE_SYNCHRONIZE)
 endif()
 
 if(gw_enable_caching_allocator)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC GW_ENABLE_CACHING_ALLOCATOR)
+    target_compile_definitions(${MODULE_NAME} PUBLIC GW_ENABLE_CACHING_ALLOCATOR)
 endif()
 
-target_include_directories(${PROJECT_NAME}
+target_include_directories(${MODULE_NAME}
     PUBLIC
         $<INSTALL_INTERFACE:include>    
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         ${CUDA_INCLUDE_DIRS}
 )
 
-install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}
+install(TARGETS ${MODULE_NAME}
+    EXPORT ${MODULE_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT ${PROJECT_NAME} DESTINATION cmake)
+install(EXPORT ${MODULE_NAME} DESTINATION cmake)
 
 # Add documentation
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/common/io/CMakeLists.txt
+++ b/common/io/CMakeLists.txt
@@ -16,17 +16,17 @@
 
 
 
-project(gwio)
+set(MODULE_NAME gwio)
 
 get_property(gw_library_type GLOBAL PROPERTY gw_library_type)
-add_library(${PROJECT_NAME} ${gw_library_type}
+add_library(${MODULE_NAME} ${gw_library_type}
         src/fasta_parser.cpp
         src/kseqpp_fasta_parser.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC gwbase z)
+target_link_libraries(${MODULE_NAME} PUBLIC gwbase z)
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include/claraparabricks/genomeworks/io)
 
-target_include_directories(${PROJECT_NAME}
+target_include_directories(${MODULE_NAME}
     PRIVATE
         ${KSEQPP_DIR}
     PUBLIC 
@@ -34,15 +34,15 @@ target_include_directories(${PROJECT_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
+target_compile_options(${MODULE_NAME} PRIVATE -Werror)
 
-install(TARGETS ${PROJECT_NAME} 
-    EXPORT ${PROJECT_NAME}
+install(TARGETS ${MODULE_NAME} 
+    EXPORT ${MODULE_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT ${PROJECT_NAME} DESTINATION cmake)
+install(EXPORT ${MODULE_NAME} DESTINATION cmake)
 
 # Add auto formatting.
 gw_enable_auto_formatting("${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cudaaligner/CMakeLists.txt
+++ b/cudaaligner/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 
 
-project(cudaaligner)
+set(MODULE_NAME cudaaligner)
 
 # Project specific NVCC flags
 if((CUDA_VERSION_MAJOR GREATER 10) OR (CUDA_VERSION_MAJOR EQUAL 10 AND CUDA_VERSION_MINOR GREATER 0))
@@ -24,10 +24,10 @@ set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++14 --expt-relaxed-constexpr")
 else()
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++14")
 endif()
-message(STATUS "nvcc flags for cudaaligner: ${CUDA_NVCC_FLAGS}")
+message(STATUS "nvcc flags for ${MODULE_NAME}: ${CUDA_NVCC_FLAGS}")
 
 get_property(gw_library_type GLOBAL PROPERTY gw_library_type)
-cuda_add_library(cudaaligner ${gw_library_type}
+cuda_add_library(${MODULE_NAME} ${gw_library_type}
     src/cudaaligner.cpp
     src/aligner.cpp
     src/alignment.cpp
@@ -44,25 +44,25 @@ cuda_add_library(cudaaligner ${gw_library_type}
     src/hirschberg_myers_gpu.cu
     )
 
-add_library(cudaaligner_internal INTERFACE)
-target_include_directories(cudaaligner_internal INTERFACE
+add_library(${MODULE_NAME}_internal INTERFACE)
+target_include_directories(${MODULE_NAME}_internal INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(cudaaligner gwbase cub)
+target_link_libraries(${MODULE_NAME} gwbase cub)
 
-target_compile_options(cudaaligner PRIVATE -Werror -Wall -Wextra)
+target_compile_options(${MODULE_NAME} PRIVATE -Werror -Wall -Wextra)
 if (gw_optimize_for_native_cpu)
     target_compile_options(cudapoa PRIVATE -march=native)
 endif()
 
-target_include_directories(cudaaligner
+target_include_directories(${MODULE_NAME}
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_compile_options(cudaaligner PRIVATE -Werror)
+target_compile_options(${MODULE_NAME} PRIVATE -Werror)
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
@@ -71,14 +71,14 @@ add_subdirectory(tests)
 add_subdirectory(benchmarks)
 add_subdirectory(samples)
 
-install(TARGETS cudaaligner
+install(TARGETS ${MODULE_NAME}
     COMPONENT logging
-    EXPORT cudaaligner
+    EXPORT ${MODULE_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT cudaaligner DESTINATION cmake)
+install(EXPORT ${MODULE_NAME} DESTINATION cmake)
 
 # Add auto formatting.
 gw_enable_auto_formatting("${CMAKE_CURRENT_SOURCE_DIR}")

--- a/cudaaligner/benchmarks/CMakeLists.txt
+++ b/cudaaligner/benchmarks/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 
 
-project(benchmark_cudaaligner)
+set(MODULE_NAME benchmark_cudaaligner)
 
 set(SOURCES
     main.cpp
@@ -28,7 +28,7 @@ set(LIBS
     cudaaligner
     gwbase)
 
-gw_add_benchmarks(${PROJECT_NAME} "cudaaligner" "${SOURCES}" "${LIBS}")
+gw_add_benchmarks(${MODULE_NAME} "cudaaligner" "${SOURCES}" "${LIBS}")
 
 install(FILES README.md
     DESTINATION benchmarks/cudaaligner)

--- a/cudaaligner/samples/CMakeLists.txt
+++ b/cudaaligner/samples/CMakeLists.txt
@@ -16,15 +16,15 @@
 
 
 
-project(sample_cudaaligner)
+set(MODULE_NAME sample_cudaaligner)
 
-add_executable(${PROJECT_NAME}
+add_executable(${MODULE_NAME}
                sample_cudaaligner.cpp
                )
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${MODULE_NAME}
                       cudaaligner
                       )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${MODULE_NAME}
             DESTINATION samples)

--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -16,14 +16,14 @@
 
 
 
-project(cudamapper)
+set(MODULE_NAME cudamapper)
 
 # Process data subdirectory first
 add_subdirectory(data)
 
 GitVersion()
 
-configure_file(${CMAKE_SOURCE_DIR}/common/base/src/version.cpp.in
+configure_file(${PROJECT_SOURCE_DIR}/common/base/src/version.cpp.in
                 ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 find_package(CUDA 9.0 QUIET REQUIRED)
@@ -41,10 +41,10 @@ else()
         CUDA_SELECT_NVCC_ARCH_FLAGS(ARCH_FLAGS "Auto")
     endif()
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${ARCH_FLAGS}")
-    message(STATUS "nvcc flags for cudamapper: ${CUDA_NVCC_FLAGS}")
+    message(STATUS "nvcc flags for ${MODULE_NAME}: ${CUDA_NVCC_FLAGS}")
 endif()
 
-cuda_add_library(cudamapper
+cuda_add_library(${MODULE_NAME}
         src/application_parameters.cpp
         src/cudamapper.cpp
         src/index_batcher.cu
@@ -62,39 +62,39 @@ cuda_add_library(cudamapper
         src/utils.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
-target_include_directories(cudamapper
+target_include_directories(${MODULE_NAME}
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_link_libraries(cudamapper gwbase gwio cub)
-target_compile_options(cudamapper PRIVATE -Werror)
+target_link_libraries(${MODULE_NAME} gwbase gwio cub)
+target_compile_options(${MODULE_NAME} PRIVATE -Werror)
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-cuda_add_executable(cudamapper-bin
+cuda_add_executable(${MODULE_NAME}-bin
         src/main.cu
 )
 
-target_compile_options(cudamapper-bin PRIVATE -Werror)
-target_link_libraries(cudamapper-bin cudamapper cudaaligner)
-set_target_properties(cudamapper-bin PROPERTIES OUTPUT_NAME cudamapper)
+target_compile_options(${MODULE_NAME}-bin PRIVATE -Werror)
+target_link_libraries(${MODULE_NAME}-bin ${MODULE_NAME} cudaaligner)
+set_target_properties(${MODULE_NAME}-bin PROPERTIES OUTPUT_NAME ${MODULE_NAME})
 
 
 # Add tests folder
 add_subdirectory(tests)
 add_subdirectory(samples)
 
-install(TARGETS cudamapper
-    EXPORT cudamapper
+install(TARGETS ${MODULE_NAME}
+    EXPORT ${MODULE_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT cudamapper DESTINATION cmake)
+install(EXPORT ${MODULE_NAME} DESTINATION cmake)
 
-install(TARGETS cudamapper-bin
-    EXPORT cudamapper-bin
+install(TARGETS ${MODULE_NAME}-bin
+    EXPORT ${MODULE_NAME}-bin
     DESTINATION bin
 )
 

--- a/cudamapper/samples/CMakeLists.txt
+++ b/cudamapper/samples/CMakeLists.txt
@@ -14,18 +14,18 @@
 # limitations under the License.
 #
 
-project(sample_cudamapper)
+set(MODULE_NAME sample_cudamapper)
 
 get_property(cudamapper_data_include_dir GLOBAL PROPERTY cudamapper_data_include_dir)
 include_directories(${cudamapper_data_include_dir})
 
-add_executable(${PROJECT_NAME}
+add_executable(${MODULE_NAME}
                sample_cudamapper.cpp
                )
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${MODULE_NAME}
                       cudamapper
                       )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${MODULE_NAME}
             DESTINATION samples)

--- a/cudapoa/CMakeLists.txt
+++ b/cudapoa/CMakeLists.txt
@@ -16,22 +16,22 @@
 
 
 
-project(cudapoa)
+set(MODULE_NAME cudapoa)
 
 # Process data subdirectory first
 add_subdirectory(data)
 
 GitVersion()
 
-configure_file(${CMAKE_SOURCE_DIR}/common/base/src/version.cpp.in
+configure_file(${PROJECT_SOURCE_DIR}/common/base/src/version.cpp.in
                 ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 # Optimization flags interfere with nvcc and cause compilation issues with reworked
 # file structure.
 if(NOT DEFINED gw_cuda_before_10_0)
-    message(FATAL_ERROR "${PROJECT_NAME} : variable gw_cuda_before_10_0 is not defined yet. Please make sure CUDA.cmake is loaded first.")
+    message(FATAL_ERROR "${MODULE_NAME} : variable gw_cuda_before_10_0 is not defined yet. Please make sure CUDA.cmake is loaded first.")
 elseif(gw_cuda_before_10_0)
-    message(STATUS "${PROJECT_NAME} : Remove -O optimization when building for CUDA < 10 as it causes compilation issues.")
+    message(STATUS "${MODULE_NAME} : Remove -O optimization when building for CUDA < 10 as it causes compilation issues.")
     string(REGEX REPLACE "-O[0-3]" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
     string(REGEX REPLACE "-O[0-3]" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
 endif()
@@ -42,32 +42,32 @@ set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++14")
 if(gw_cuda_after_10_0)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --expt-relaxed-constexpr")
 endif()
-message(STATUS "nvcc flags for ${PROJECT_NAME}: ${CUDA_NVCC_FLAGS}")
+message(STATUS "nvcc flags for ${MODULE_NAME}: ${CUDA_NVCC_FLAGS}")
 
 get_property(gw_library_type GLOBAL PROPERTY gw_library_type)
-cuda_add_library(cudapoa ${gw_library_type}
+cuda_add_library(${MODULE_NAME} ${gw_library_type}
     src/cudapoa.cpp
     src/batch.cu
     src/utils.cu
     ${CMAKE_CURRENT_BINARY_DIR}/version.cpp
     )
 
-target_link_libraries(cudapoa gwbase gwio)
+target_link_libraries(${MODULE_NAME} gwbase gwio)
 
-target_compile_options(cudapoa PRIVATE -Werror -Wall -Wextra)
+target_compile_options(${MODULE_NAME} PRIVATE -Werror -Wall -Wextra)
 if (gw_optimize_for_native_cpu)
-    target_compile_options(cudapoa PRIVATE -march=native)
+    target_compile_options(${MODULE_NAME} PRIVATE -march=native)
 endif()
 
 if(gw_enable_cudapoa_nw_print)
-    target_compile_definitions(cudapoa PUBLIC NW_VERBOSE_PRINT)
+    target_compile_definitions(${MODULE_NAME} PUBLIC NW_VERBOSE_PRINT)
 endif()
 
 if(spoa_accurate)
-    target_compile_definitions(cudapoa PUBLIC SPOA_ACCURATE)
+    target_compile_definitions(${MODULE_NAME} PUBLIC SPOA_ACCURATE)
 endif()
 
-target_include_directories(cudapoa
+target_include_directories(${MODULE_NAME}
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -75,33 +75,33 @@ target_include_directories(cudapoa
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_executable(cudapoa-bin
+add_executable(${MODULE_NAME}-bin
         src/main.cpp
         src/application_parameters.hpp
         src/application_parameters.cpp
 )
 
-target_include_directories(cudapoa-bin
+target_include_directories(${MODULE_NAME}-bin
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_compile_options(cudapoa-bin PRIVATE -Werror)
-target_link_libraries(cudapoa-bin gwio cudapoa gwbase)
-set_target_properties(cudapoa-bin PROPERTIES OUTPUT_NAME cudapoa)
+target_compile_options(${MODULE_NAME}-bin PRIVATE -Werror)
+target_link_libraries(${MODULE_NAME}-bin gwio ${MODULE_NAME} gwbase)
+set_target_properties(${MODULE_NAME}-bin PROPERTIES OUTPUT_NAME ${MODULE_NAME})
 
-install(TARGETS cudapoa
+install(TARGETS ${MODULE_NAME}
     COMPONENT gwlogging
-    EXPORT cudapoa
+    EXPORT ${MODULE_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include
 )
 install(DIRECTORY include/ DESTINATION include)
-install(EXPORT cudapoa DESTINATION cmake)
+install(EXPORT ${MODULE_NAME} DESTINATION cmake)
 
-install(TARGETS cudapoa-bin
-    EXPORT cudapoa-bin
+install(TARGETS ${MODULE_NAME}-bin
+    EXPORT ${MODULE_NAME}-bin
     DESTINATION bin
 )
 

--- a/cudapoa/benchmarks/CMakeLists.txt
+++ b/cudapoa/benchmarks/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 ## Add benchmark to cudapoa project
 
-project(benchmark_cudapoa)
+set(MODULE_NAME benchmark_cudapoa)
 
 set(SOURCES
         main.cpp
@@ -29,7 +29,7 @@ include_directories(${cudapoa_data_include_dir})
 set(LIBS
         cudapoa)
 
-gw_add_benchmarks(${PROJECT_NAME} "cudapoa" "${SOURCES}" "${LIBS}")
+gw_add_benchmarks(${MODULE_NAME} "cudapoa" "${SOURCES}" "${LIBS}")
 
 install(FILES README.md
     DESTINATION benchmarks/cudapoa)

--- a/cudapoa/samples/CMakeLists.txt
+++ b/cudapoa/samples/CMakeLists.txt
@@ -16,18 +16,18 @@
 
 
 
-project(sample_cudapoa)
+set(MODULE_NAME sample_cudapoa)
 
 get_property(cudapoa_data_include_dir GLOBAL PROPERTY cudapoa_data_include_dir)
 include_directories(${cudapoa_data_include_dir})
 
-add_executable(${PROJECT_NAME}
+add_executable(${MODULE_NAME}
                sample_cudapoa.cpp
                )
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${MODULE_NAME}
                       cudapoa
                       )
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${MODULE_NAME}
             DESTINATION samples)


### PR DESCRIPTION
Update cmake structure for better integration with
other tools that use GW as cmake submodule.

Keep only one project for GW, and remove "project" settings
from all modules.