### PR TITLE
[cudamapper] Minimizer uses thrust::inclusive_scan

### DIFF
--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -1055,10 +1055,6 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(DefaultDe
     GW_LOG_INFO("Deallocating {} bytes from read_id_to_windows_section_d", read_id_to_windows_section_d.size() * sizeof(decltype(read_id_to_windows_section_d)::value_type));
     read_id_to_windows_section_d.free();
 
-    // This is not completely necessary, but if removed one has to make sure that the next step
-    // uses the same stream or that sync is done in caller
-    GW_CU_CHECK_ERR(cudaStreamSynchronize(cuda_stream));
-
     return {std::move(representations_compressed_d),
             std::move(rest_compressed_d)};
 }

--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -848,6 +848,7 @@ __global__ void find_back_end_minimizers(const std::uint64_t minimizer_size,
 /// \param representations_compressed array of representations of minimizers, grouped by reads, without invalid elements between the reads
 /// \param rest_compressed array of read_ids, positions_in_read and directions of reads, grouped by reads, without invalid elements between the reads
 /// \param read_id_to_compressed_minimizers index of the first minimizer of the next read (array comes from an inclusive scan, hence all indices are shifted by one)
+/// \param read_id_of_first_read
 __global__ void compress_minimizers(const representation_t* const window_minimizers_representation,
                                     const position_in_read_t* const window_minimizers_position_in_read,
                                     const char* const window_minimizers_direction,
@@ -855,7 +856,7 @@ __global__ void compress_minimizers(const representation_t* const window_minimiz
                                     representation_t* const representations_compressed,
                                     Minimizer::ReadidPositionDirection* const rest_compressed,
                                     const std::int64_t* const read_id_to_compressed_minimizers,
-                                    std::uint32_t offset)
+                                    std::uint32_t read_id_of_first_read)
 {
     const auto& first_input_minimizer = read_id_to_windows_section[blockIdx.x].first_element_;
     // elements have the index of read_id+1, i.e. everything is shifted by one
@@ -865,7 +866,7 @@ __global__ void compress_minimizers(const representation_t* const window_minimiz
     for (std::uint32_t i = threadIdx.x; i < number_of_minimizers; i += blockDim.x)
     {
         representations_compressed[first_output_minimizer + i]        = window_minimizers_representation[first_input_minimizer + i];
-        rest_compressed[first_output_minimizer + i].read_id_          = blockIdx.x + offset;
+        rest_compressed[first_output_minimizer + i].read_id_          = blockIdx.x + read_id_of_first_read;
         rest_compressed[first_output_minimizer + i].position_in_read_ = window_minimizers_position_in_read[first_input_minimizer + i];
         rest_compressed[first_output_minimizer + i].direction_        = window_minimizers_direction[first_input_minimizer + i];
     }

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -82,6 +82,8 @@ public:
 
     /// \brief generates sketch elements from the given input
     ///
+    /// This function does not sync at the end
+    ///
     /// \param number_of_reads_to_add number of reads which should be added to the collection (= number of reads in the data that is passed to the function)
     /// \param minimizer_size
     /// \param window_size


### PR DESCRIPTION
`Minimizer::generate_sketch_elements()` now uses `thrust::inclusive_scan()` to determine positions of reads' minimizers on device, instead of doing it on host. Total number of reads is small and the total number of minimizers still has to be copied to host so performance gains are not big, but it makes the code significantly cleaner.

This PR also removes `cudaStreamSynchronize()` from the end of `Minimizer::generate_sketch_elements()`, but note that freeing `device_buffer`s (for now) contains calls to `cudaStreamSynchronize()`