### PR TITLE
[cmake] push fixes for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ string(STRIP ${GW_VERSION} GW_VERSION)
 project(${GW_PROJECT_NAME})
 
 # Process options.
-option(gw_enable_tests "Build GenomeWorks unit tests" OFF)
-option(gw_enable_benchmarks "Build GenomeWorks benchmarks" OFF)
+option(gw_enable_tests "Build GenomeWorks unit tests" ON)
+option(gw_enable_benchmarks "Build GenomeWorks benchmarks" ON)
 option(gw_build_shared "Build GenomeWorks libraries as shared objects" OFF)
 option(gw_device_synchronize_kernels "Run cudaDeviceSynchronize() in GW_CU_CHECK_ERR calls" OFF)
 option(gw_optimize_for_native_cpu "Build with march=native" ON)

--- a/cudaextender/CMakeLists.txt
+++ b/cudaextender/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(data)
 
 GitVersion()
 
-configure_file(${CMAKE_SOURCE_DIR}/common/base/src/version.cpp.in
+configure_file(${PROJECT_SOURCE_DIR}/common/base/src/version.cpp.in
         ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
 
 # Project specific NVCC flags, --expt-relaxed-constexpr is being added to allow using numeric_limits inside device kernels.


### PR DESCRIPTION
1. fix usage of CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR
2. make tests and benchmarks build by default