### PR TITLE
[logging] fix spdlog incompatibility with gcc9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ option(gw_enable_caching_allocator "Enable caching allocator." ON)
 option(gw_generate_docs "Generate Doxygen documentation" ON)
 option(gw_cuda_gen_all_arch "ON: Generate optimized CUDA code for all architectures | OFF: for detected architectures only" OFF)
 # Optionally build htslib for SAM/BAM support. Requires autoconf to be installed
-option(gw_build_htslib "Build 3rdparty htslib that allows output in SAM/BAM format" OFF)
+option(gw_build_htslib "Build 3rdparty htslib that allows output in SAM/BAM format" ON)
 
 # Must be included before others for options value validation
 include(cmake/Utils.cmake)

--- a/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
+++ b/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
@@ -94,7 +94,11 @@
 #ifdef GW_CUDA_BEFORE_9_2
 // Due to a header file incompatibility with nvcc in CUDA 9.0
 // logging through the logger class in GW is disabled for any .cu files.
+#elif __GNUC__  >= 9
 #pragma message("Logging disabled for CUDA Toolkit < 9.2")
+// Due to a ISO C++ standard incompatibility the spdlog fails to pass
+// pedantic requirements.
+#pragma message("Logging disabled for GCC >= 9")
 #else
 #include <spdlog/spdlog.h>
 #endif
@@ -137,6 +141,8 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_DEBUG(...)
+#elif __GNUC__  >= 9
+#define GW_LOG_DEBUG(...)
 #else
 #define GW_LOG_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
 #endif
@@ -147,6 +153,8 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 ///
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
+#define GW_LOG_INFO(...)
+#elif __GNUC__  >= 9
 #define GW_LOG_INFO(...)
 #else
 #define GW_LOG_INFO(...) SPDLOG_INFO(__VA_ARGS__)
@@ -159,6 +167,8 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_WARN(...)
+#elif __GNUC__  >= 9
+#define GW_LOG_WARN(...)
 #else
 #define GW_LOG_WARN(...) SPDLOG_WARN(__VA_ARGS__)
 #endif
@@ -170,6 +180,8 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_ERROR(...)
+#elif __GNUC__  >= 9
+#define GW_LOG_ERROR(...)
 #else
 #define GW_LOG_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
 #endif
@@ -180,6 +192,8 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 ///
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
+#define GW_LOG_CRITICAL(...)
+#elif __GNUC__  >= 9
 #define GW_LOG_CRITICAL(...)
 #else
 #define GW_LOG_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)

--- a/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
+++ b/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
@@ -94,7 +94,7 @@
 #ifdef GW_CUDA_BEFORE_9_2
 // Due to a header file incompatibility with nvcc in CUDA 9.0
 // logging through the logger class in GW is disabled for any .cu files.
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #pragma message("Logging disabled for CUDA Toolkit < 9.2")
 // Due to a ISO C++ standard incompatibility the spdlog fails to pass
 // pedantic requirements.
@@ -141,7 +141,7 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_DEBUG(...)
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #define GW_LOG_DEBUG(...)
 #else
 #define GW_LOG_DEBUG(...) SPDLOG_DEBUG(__VA_ARGS__)
@@ -154,7 +154,7 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_INFO(...)
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #define GW_LOG_INFO(...)
 #else
 #define GW_LOG_INFO(...) SPDLOG_INFO(__VA_ARGS__)
@@ -167,7 +167,7 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_WARN(...)
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #define GW_LOG_WARN(...)
 #else
 #define GW_LOG_WARN(...) SPDLOG_WARN(__VA_ARGS__)
@@ -180,7 +180,7 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_ERROR(...)
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #define GW_LOG_ERROR(...)
 #else
 #define GW_LOG_ERROR(...) SPDLOG_ERROR(__VA_ARGS__)
@@ -193,7 +193,7 @@ LoggingStatus SetHeader(bool logTime, bool logLocation);
 /// parameters as per https://github.com/gabime/spdlog/blob/v1.x/README.md
 #ifdef GW_CUDA_BEFORE_9_2
 #define GW_LOG_CRITICAL(...)
-#elif __GNUC__  >= 9
+#elif __GNUC__ >= 9
 #define GW_LOG_CRITICAL(...)
 #else
 #define GW_LOG_CRITICAL(...) SPDLOG_CRITICAL(__VA_ARGS__)

--- a/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
+++ b/common/base/include/claraparabricks/genomeworks/logging/logging.hpp
@@ -94,8 +94,8 @@
 #ifdef GW_CUDA_BEFORE_9_2
 // Due to a header file incompatibility with nvcc in CUDA 9.0
 // logging through the logger class in GW is disabled for any .cu files.
-#elif __GNUC__ >= 9
 #pragma message("Logging disabled for CUDA Toolkit < 9.2")
+#elif __GNUC__ >= 9
 // Due to a ISO C++ standard incompatibility the spdlog fails to pass
 // pedantic requirements.
 #pragma message("Logging disabled for GCC >= 9")

--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(${MODULE_NAME}
 
 # optionally link against htslib
 if (TARGET htslib_project)
-    add_compile_definitions(GW_BUILD_HTSLIB)
+    target_compile_definitions(${MODULE_NAME} PUBLIC GW_BUILD_HTSLIB)
     add_dependencies(${MODULE_NAME} htslib_project)
     target_link_libraries(${MODULE_NAME} htslib gwbase gwio cub)
 else()

--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -87,6 +87,9 @@ cuda_add_executable(${MODULE_NAME}-bin
 target_compile_options(${MODULE_NAME}-bin PRIVATE -Werror)
 target_link_libraries(${MODULE_NAME}-bin ${MODULE_NAME} cudaaligner)
 set_target_properties(${MODULE_NAME}-bin PROPERTIES OUTPUT_NAME ${MODULE_NAME})
+if (TARGET htslib_project)
+    target_compile_definitions(${MODULE_NAME}-bin PUBLIC GW_BUILD_HTSLIB)
+endif()
 
 
 # Add tests folder

--- a/cudamapper/samples/CMakeLists.txt
+++ b/cudamapper/samples/CMakeLists.txt
@@ -27,5 +27,11 @@ target_link_libraries(${MODULE_NAME}
                       cudamapper
                       )
 
+if (TARGET htslib_project)
+    target_compile_definitions(${MODULE_NAME}
+                               PUBLIC
+                               GW_BUILD_HTSLIB)
+endif()
+
 install(TARGETS ${MODULE_NAME}
             DESTINATION samples)


### PR DESCRIPTION
1. WAR fix for spdlog with gcc9. disable logging for gcc9
2. enable SAM support by default and fix cmake compile option for SAM