### PR TITLE
[cudaaligner]: Fix cmake for cudaaligner optimization flag

### DIFF
--- a/cudaaligner/CMakeLists.txt
+++ b/cudaaligner/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(${MODULE_NAME} gwbase cub)
 
 target_compile_options(${MODULE_NAME} PRIVATE -Werror -Wall -Wextra)
 if (gw_optimize_for_native_cpu)
-    target_compile_options(cudapoa PRIVATE -march=native)
+    target_compile_options(${MODULE_NAME} PRIVATE -march=native)
 endif()
 
 target_include_directories(${MODULE_NAME}


### PR DESCRIPTION
Inside of the cudaaligner module, cmake was setting the compile target to cudapoa instead of `${MODULE_NAME}`