### PR TITLE
[cudaaligner] Add support for extended CIGAR

### DIFF
--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
@@ -69,7 +69,7 @@ public:
     ///        supporting only M, I and D states.
     ///
     /// \return CIGAR string
-    virtual std::string convert_to_cigar() const = 0;
+    virtual std::string convert_to_cigar(CigarFormat format = CigarFormat::basic) const = 0;
 
     /// \brief Returns type of alignment
     ///

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/cudaaligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/cudaaligner.hpp
@@ -57,6 +57,13 @@ enum AlignmentState : int8_t
     deletion   // Present in query, absent in target
 };
 
+/// CigarFormat - Enum to switch between different CIGAR formats.
+enum CigarFormat
+{
+    basic = 0, // Basic format. Symbols: I,D,M
+    extended   // Extended format. Symbols: I,D,X,=
+};
+
 /// Initialize CUDA Aligner context.
 StatusType Init();
 /// \}

--- a/cudaaligner/src/alignment_impl.cpp
+++ b/cudaaligner/src/alignment_impl.cpp
@@ -48,7 +48,8 @@ char alignment_state_to_cigar_state(AlignmentState s)
 char alignment_state_to_cigar_state_extended(AlignmentState s)
 {
     // CIGAR string format from http://bioinformatics.cvr.ac.uk/blog/tag/cigar-string/
-    // Implementing a reduced set of CIGAR states, covering only the M, D and I characters.
+    // Implementing the set of CIGAR states with =, X, D and I characters,
+    // which distingishes matches and mismatches.
     switch (s)
     {
     case AlignmentState::match: return '=';
@@ -91,7 +92,7 @@ std::string convert_to_cigar_impl(const std::vector<AlignmentState>& alignment, 
 
 } // namespace
 
-AlignmentImpl::AlignmentImpl(const char* query, int32_t query_length, const char* target, int32_t target_length)
+AlignmentImpl::AlignmentImpl(const char* const query, const int32_t query_length, const char* const target, const int32_t target_length)
     : query_(query, query + throw_on_negative(query_length, "query_length has to be non-negative."))
     , target_(target, target + throw_on_negative(target_length, "target_length has to be non-negative."))
     , status_(StatusType::uninitialized)
@@ -102,7 +103,7 @@ AlignmentImpl::AlignmentImpl(const char* query, int32_t query_length, const char
     // Initialize Alignment object.
 }
 
-std::string AlignmentImpl::convert_to_cigar(CigarFormat format) const
+std::string AlignmentImpl::convert_to_cigar(const CigarFormat format) const
 {
     if (format == CigarFormat::extended)
         return convert_to_cigar_impl(alignment_, alignment_state_to_cigar_state_extended);

--- a/cudaaligner/src/alignment_impl.hpp
+++ b/cudaaligner/src/alignment_impl.hpp
@@ -47,7 +47,7 @@ public:
     /// \brief Converts an alignment to CIGAR format
     ///
     /// \return CIGAR string
-    std::string convert_to_cigar() const override;
+    std::string convert_to_cigar(CigarFormat format) const override;
 
     /// \brief Set alignment type.
     /// \param type Alignment type.

--- a/cudaaligner/tests/Test_AlignmentImpl.cpp
+++ b/cudaaligner/tests/Test_AlignmentImpl.cpp
@@ -59,7 +59,8 @@ typedef struct AlignmentTestData
     std::vector<AlignmentState> alignment;
     bool is_optimal;
     FormattedAlignment formatted_alignment;
-    std::string cigar;
+    std::string cigar_basic;
+    std::string cigar_extended;
 } AlignmentTestData;
 
 std::vector<AlignmentTestData> create_alignment_test_cases()
@@ -78,7 +79,8 @@ std::vector<AlignmentTestData> create_alignment_test_cases()
         AlignmentState::insertion};
     data.is_optimal          = true;
     data.formatted_alignment = FormattedAlignment{"AAAA-", "xx|x ", "TTATG"};
-    data.cigar               = "4M1I";
+    data.cigar_basic         = "4M1I";
+    data.cigar_extended      = "2X1=1X1I";
     test_cases.push_back(data);
 
     // Test case 2
@@ -95,7 +97,8 @@ std::vector<AlignmentTestData> create_alignment_test_cases()
         AlignmentState::deletion};
     data.is_optimal          = true;
     data.formatted_alignment = FormattedAlignment{"CGATAATG", " x||||  ", "-CATAA--"};
-    data.cigar               = "1D5M2D";
+    data.cigar_basic         = "1D5M2D";
+    data.cigar_extended      = "1D1X4=2D";
     test_cases.push_back(data);
 
     // Test case 3
@@ -115,7 +118,8 @@ std::vector<AlignmentTestData> create_alignment_test_cases()
     };
     data.is_optimal          = true;
     data.formatted_alignment = FormattedAlignment{"--GT-TAG--", "  || |||  ", "AAGTCTAGAA"};
-    data.cigar               = "2I2M1I3M2I";
+    data.cigar_basic         = "2I2M1I3M2I";
+    data.cigar_extended      = "2I2=1I3=2I";
     test_cases.push_back(data);
 
     // Test case 4
@@ -131,7 +135,8 @@ std::vector<AlignmentTestData> create_alignment_test_cases()
         AlignmentState::match};
     data.is_optimal          = false; // this example is optimal, but is_optimal = false does only mean it is an upper bound
     data.formatted_alignment = FormattedAlignment{"G-TTACA", "| || ||", "GATT-CA"};
-    data.cigar               = "1M1I2M1D2M";
+    data.cigar_basic         = "1M1I2M1D2M";
+    data.cigar_extended      = "1=1I2=1D2=";
     test_cases.push_back(data);
 
     return test_cases;
@@ -184,10 +189,16 @@ TEST_P(TestAlignmentImpl, AlignmentFormatting)
     ASSERT_EQ(param_.formatted_alignment.target, formatted_alignment.target);
 }
 
-TEST_P(TestAlignmentImpl, CigarFormatting)
+TEST_P(TestAlignmentImpl, CigarFormattingBasic)
 {
-    std::string cigar = alignment_->convert_to_cigar();
-    ASSERT_EQ(param_.cigar, cigar);
+    std::string cigar = alignment_->convert_to_cigar(CigarFormat::basic);
+    ASSERT_EQ(param_.cigar_basic, cigar);
+}
+
+TEST_P(TestAlignmentImpl, CigarFormattingExtended)
+{
+    std::string cigar = alignment_->convert_to_cigar(CigarFormat::extended);
+    ASSERT_EQ(param_.cigar_extended, cigar);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestAlignment, TestAlignmentImpl, ValuesIn(create_alignment_test_cases()));


### PR DESCRIPTION
Add support for extended CIGAR which distinguishes matches '=' and mismatches 'X'.