### PR TITLE
Add missing error checks to avoid silent errors

### DIFF
--- a/common/base/include/claraparabricks/genomeworks/utils/cudautils.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/cudautils.hpp
@@ -83,10 +83,12 @@ inline void gpu_assert(cudaError_t code, const char* file, int line)
 
     if (code != cudaSuccess)
     {
-        std::string err = "GPU Error:: " +
-                          std::string(cudaGetErrorString(code)) +
-                          " " + std::string(file) +
-                          " " + std::to_string(line);
+        std::string err = "GPU Error:: " + std::string(cudaGetErrorString(code));
+        if (code == cudaErrorNoKernelImageForDevice)
+        {
+            err += " -- Is the code compiled for the correct GPU architecture?";
+        }
+        err += " " + std::string(file) + " " + std::to_string(line);
         GW_LOG_ERROR(err.c_str());
         // In Debug mode, this assert will cause a debugger trap
         // which is beneficial when debugging errors.

--- a/common/base/include/claraparabricks/genomeworks/utils/cudautils.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/cudautils.hpp
@@ -87,6 +87,18 @@ inline void gpu_assert(cudaError_t code, const char* file, int line)
         if (code == cudaErrorNoKernelImageForDevice)
         {
             err += " -- Is the code compiled for the correct GPU architecture?";
+            int32_t device;
+            cudaDeviceProp prop;
+            if (cudaGetDevice(&device) == cudaSuccess)
+            {
+                if (cudaGetDeviceProperties(&prop, device) == cudaSuccess)
+                {
+                    err += " Device has compute capability ";
+                    err += std::to_string(prop.major);
+                    err += std::to_string(prop.minor);
+                    err += ".";
+                }
+            }
         }
         err += " " + std::string(file) + " " + std::to_string(line);
         GW_LOG_ERROR(err.c_str());

--- a/cudaaligner/src/myers_gpu.cu
+++ b/cudaaligner/src/myers_gpu.cu
@@ -909,6 +909,7 @@ int32_t myers_compute_edit_distance(std::string const& target, std::string const
     GW_CU_CHECK_ERR(cudaMemcpyAsync(sequence_lengths_d.data(), lengths.data(), sizeof(int32_t) * 2, cudaMemcpyHostToDevice, stream.get()));
 
     myers::myers_compute_score_matrix_kernel<<<1, warp_size, 0, stream.get()>>>(pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), query_patterns.get_device_interface(), sequences_d.data(), sequence_lengths_d.data(), max_sequence_length, 1);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     matrix<int32_t> score_host = score.get_matrix(0, n_words, get_size(target) + 1, stream.get());
     return score_host(n_words - 1, get_size(target));
@@ -953,12 +954,14 @@ matrix<int32_t> myers_get_full_score_matrix(std::string const& target, std::stri
     GW_CU_CHECK_ERR(cudaMemcpyAsync(sequence_lengths_d.data(), lengths.data(), sizeof(int32_t) * 2, cudaMemcpyHostToDevice, stream.get()));
 
     myers::myers_compute_score_matrix_kernel<<<1, warp_size, 0, stream.get()>>>(pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), query_patterns.get_device_interface(), sequences_d.data(), sequence_lengths_d.data(), max_sequence_length, 1);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
     {
         dim3 n_threads = {32, 4, 1};
         dim3 n_blocks  = {1, 1, 1};
         n_blocks.x     = ceiling_divide<int32_t>(get_size<int32_t>(query) + 1, n_threads.x);
         n_blocks.y     = ceiling_divide<int32_t>(get_size<int32_t>(target) + 1, n_threads.y);
         myers::myers_convert_to_full_score_matrix_kernel<<<n_blocks, n_threads, 0, stream.get()>>>(fullscore.get_device_interface(), pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), sequence_lengths_d.data(), 0);
+        GW_CU_CHECK_ERR(cudaPeekAtLastError());
     }
 
     matrix<int32_t> fullscore_host = fullscore.get_matrix(0, get_size(query) + 1, get_size(target) + 1, stream.get());
@@ -986,6 +989,7 @@ void myers_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length
         const dim3 blocks(ceiling_divide<int32_t>(n_alignments, threads.x), 1, 1);
         myers::myers_backtrace_kernel<<<blocks, threads, 0, stream>>>(paths_d, path_lengths_d, max_path_length, pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), sequence_lengths_d, n_alignments);
     }
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 }
 
 void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
@@ -1004,6 +1008,7 @@ void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int64_t const* p
     myers::myers_banded_kernel<<<blocks, threads, 0, stream>>>(paths_d, path_lengths_d, path_starts_d,
                                                                pv.get_device_interface(), mv.get_device_interface(), score.get_device_interface(), query_patterns.get_device_interface(),
                                                                sequences_d, sequence_starts_d, max_bandwidth, n_alignments);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 }
 
 } // namespace cudaaligner

--- a/cudaaligner/tests/Test_HirschbergMyers.cu
+++ b/cudaaligner/tests/Test_HirschbergMyers.cu
@@ -64,6 +64,7 @@ matrix<WordType> compute_myers_preprocess_matrix(std::string query_host)
 
     batched_device_matrices<WordType> query_pattern(1, 8 * n_words, allocator, stream);
     myers_preprocess_kernel<<<1, 32>>>(query_pattern.get_device_interface(), query.data(), query.size());
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
     return query_pattern.get_matrix(0, n_words, 8, stream);
 }
 
@@ -77,9 +78,11 @@ std::vector<WordType> myers_get_query_pattern_test(std::string query_host, int32
     GW_CU_CHECK_ERR(cudaMemcpy(query.data(), query_host.data(), sizeof(char) * query.size(), cudaMemcpyHostToDevice));
     batched_device_matrices<WordType> query_pattern(1, 8 * n_words, allocator, stream);
     myers_preprocess_kernel<<<1, 32>>>(query_pattern.get_device_interface(), query.data(), query.size());
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     device_buffer<WordType> result(32, allocator);
     myers_get_query_pattern_test_kernel<<<1, 32>>>(n_words, result.data(), query_pattern.get_device_interface(), idx, x, reverse);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     std::vector<WordType> result_host(result.size());
     cudaMemcpy(result_host.data(), result.data(), sizeof(WordType) * result.size(), cudaMemcpyDeviceToHost);

--- a/cudaaligner/tests/Test_MyersAlgorithm.cu
+++ b/cudaaligner/tests/Test_MyersAlgorithm.cu
@@ -224,6 +224,7 @@ TEST_P(TestMyersBandedMatrixDeltas, TestCases)
         pvs.get_device_interface(), mvs.get_device_interface(),
         scores.get_device_interface(), query_patterns.get_device_interface(),
         target_d.data(), query_d.data(), target_size, query_size, band_width, p);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     const int32_t n_rows             = n_words_band;
     const int32_t n_cols             = target_size + 1;

--- a/cudaextender/src/ungapped_xdrop.cu
+++ b/cudaextender/src/ungapped_xdrop.cu
@@ -129,6 +129,7 @@ StatusType UngappedXDrop::extend_async(const int8_t* d_query, const int32_t quer
                                                                    seed_pair_start,
                                                                    d_scored_segment_pairs,
                                                                    d_done_.data());
+        GW_CU_CHECK_ERR(cudaPeekAtLastError());
         size_t cub_storage_bytes = d_temp_storage_cub_.size();
         GW_CU_CHECK_ERR(cub::DeviceScan::InclusiveSum(d_temp_storage_cub_.data(),
                                                       cub_storage_bytes,
@@ -150,6 +151,7 @@ StatusType UngappedXDrop::extend_async(const int8_t* d_query, const int32_t quer
                                                         d_scored_segment_pairs,
                                                         d_tmp_ssp_.data(),
                                                         curr_num_pairs);
+            GW_CU_CHECK_ERR(cudaPeekAtLastError());
             thrust::stable_sort(thrust::cuda::par(allocator_).on(stream_),
                                 d_tmp_ssp_.begin(),
                                 d_tmp_ssp_.begin() + num_scored_segment_pairs,

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -78,6 +78,7 @@ void find_first_occurrences_of_representations(DefaultDeviceAllocator allocator,
                                                                                                               representation_index_mask_d.size(),
                                                                                                               first_occurrence_index_d.data(),
                                                                                                               unique_representations_d.data());
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
     // last element is the total number of elements in representations array
 
     std::uint32_t input_representations_size = input_representations_d.size();

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -539,6 +539,7 @@ void filter_out_most_common_representations(DefaultDeviceAllocator allocator,
                                                                                                                     unique_representation_index_after_filtering_d.data(),
                                                                                                                     unique_representations_after_compression_d.data(),
                                                                                                                     first_occurrence_of_representations_after_compression_d.data());
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // *** remove filtered out elements (compress) from other data arrays ***
 
@@ -573,6 +574,7 @@ void filter_out_most_common_representations(DefaultDeviceAllocator allocator,
                                                                                                          read_ids_after_compression_d.data(),
                                                                                                          positions_in_reads_after_compression_d.data(),
                                                                                                          directions_of_representations_after_compression_d.data());
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // *** swap vectors with the input arrays ***
     swap(unique_representations_d, unique_representations_after_compression_d);
@@ -944,6 +946,7 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
                                                                                               positions_in_reads_d_.data(),
                                                                                               directions_of_reads_d_.data(),
                                                                                               representations_d_.size());
+        GW_CU_CHECK_ERR(cudaPeekAtLastError());
     }
 
     // now generate the index elements

--- a/cudamapper/src/matcher_gpu.cu
+++ b/cudamapper/src/matcher_gpu.cu
@@ -310,6 +310,7 @@ void generate_anchors(
             target_index.smallest_read_id(),
             target_index.number_of_reads(),
             target_index.number_of_basepairs_in_longest_read());
+        GW_CU_CHECK_ERR(cudaPeekAtLastError());
     }
 
     {
@@ -342,6 +343,7 @@ void find_query_target_matches(
                                                                               get_size(query_representations_d),
                                                                               target_representations_d.data(),
                                                                               get_size(target_representations_d));
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 }
 
 void compute_anchor_starting_indices(

--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -948,6 +948,7 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(DefaultDe
                                                                                                                  read_id_to_windows_section_d.data(),
                                                                                                                  read_id_to_minimizers_written_d.data(),
                                                                                                                  hash_representations);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // *** central minimizers ***
     const std::uint32_t basepairs_per_thread    = 8;  // arbitrary, tradeoff between the number of thread blocks that can be scheduled simultaneously and the number of basepairs which have to be loaded multiple times beacuse only basepairs_per_thread*num_of_threads-(window_size_ + minimizer_size_ - 1) + 1 can be processed at once, i.e. window_size+minimizer_size-2 basepairs have to be loaded again
@@ -982,6 +983,7 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(DefaultDe
                                                                                                                read_id_to_windows_section_d.data(),
                                                                                                                read_id_to_minimizers_written_d.data(),
                                                                                                                hash_representations);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // *** back end minimizers ***
     num_of_threads = 64;
@@ -1009,6 +1011,7 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(DefaultDe
                                                                                                                 read_id_to_windows_section_d.data(),
                                                                                                                 read_id_to_minimizers_written_d.data(),
                                                                                                                 hash_representations);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // *** remove unused elemets from the window minimizers arrays ***
     // In window_minimizers_representation_d and other arrays enough space was allocated to support cases in which each window has a different minimizer. In reality many neighboring windows share the same minimizer
@@ -1039,6 +1042,7 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(DefaultDe
                                                                          rest_compressed_d.data(),
                                                                          read_id_to_minimizers_written_d.data(),
                                                                          read_id_of_first_read);
+    GW_CU_CHECK_ERR(cudaPeekAtLastError());
 
     // free these arrays as they are not needed anymore
     window_minimizers_representation_d.free();


### PR DESCRIPTION
Adding error checks after all kernel calls to avoid silent errors.
This is especially important for `cudaErrorNoKernelImageForDevice` errors. Those errors happen when the kernels are launched on a GPU which does not match the architecture the code was compiled for and the runtime has cannot jit-compile the kernels due to missing or incompatible PTX code.