### PR TITLE
[cudaaligner] Add aligner.reset_bandwidth(int32_t) to banded Myers aligner

### DIFF
--- a/common/base/include/claraparabricks/genomeworks/utils/limits.cuh
+++ b/common/base/include/claraparabricks/genomeworks/utils/limits.cuh
@@ -26,6 +26,7 @@ namespace claraparabricks
 namespace genomeworks
 {
 #ifdef GW_CUDA_BEFORE_10_1
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 template <typename T>
 struct numeric_limits
@@ -45,6 +46,7 @@ struct numeric_limits<int32_t>
     GW_CONSTEXPR static __device__ int32_t max() { return INT32_MAX; }
     GW_CONSTEXPR static __device__ int32_t min() { return INT32_MIN; }
 };
+#pragma GCC diagnostic pop
 #else
 using std::numeric_limits;
 #endif

--- a/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
@@ -17,7 +17,10 @@
 #pragma once
 
 #include <vector>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #include <thrust/system/cuda/experimental/pinned_allocator.h>
+#pragma GCC diagnostic pop
 
 namespace claraparabricks
 {

--- a/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/pinned_host_vector.hpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <thrust/system/cuda/experimental/pinned_allocator.h>
 #pragma GCC diagnostic pop
 

--- a/cudaaligner/src/aligner_global_myers_banded.hpp
+++ b/cudaaligner/src/aligner_global_myers_banded.hpp
@@ -44,15 +44,20 @@ public:
         return alignments_;
     }
 
+    void reset_bandwidth(int32_t max_bandwidth);
+
 private:
+    struct InternalData;
+
+    static void reallocate_internal_data(InternalData* data, int64_t max_device_memory, int32_t max_bandwidth, int32_t n_alignments_initial, cudaStream_t stream);
     void reset_data();
 
-    struct InternalData;
     std::unique_ptr<InternalData> data_;
     cudaStream_t stream_;
     int32_t device_id_;
     int32_t max_bandwidth_;
     std::vector<std::shared_ptr<Alignment>> alignments_;
+    int64_t max_device_memory_;
 };
 
 } // namespace cudaaligner

--- a/cudaaligner/src/myers_gpu.cu
+++ b/cudaaligner/src/myers_gpu.cu
@@ -14,9 +14,6 @@
 * limitations under the License.
 */
 
-// This is required for the unused parameter error raised by cuda/atomic
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
 #include "myers_gpu.cuh"
 #include "batched_device_matrices.cuh"
 
@@ -32,7 +29,10 @@
 #include <climits>
 #include <vector>
 #include <numeric>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <cuda/atomic>
+#pragma GCC diagnostic pop
 
 namespace claraparabricks
 {


### PR DESCRIPTION
* Make `batched_device_matrices` default-constructible.
* Add `aligner.reset_bandwidth(int32_t)` to banded Myers aligner.

Proper tests of `reset_bandwidth()` will follow in a separate PR.