### PR TITLE
[cudaaligner] Introduce FixedBandAligner interface

### DIFF
--- a/common/base/include/claraparabricks/genomeworks/utils/device_buffer.hpp
+++ b/common/base/include/claraparabricks/genomeworks/utils/device_buffer.hpp
@@ -105,7 +105,7 @@ public:
     buffer(buffer&& rhs)
         : data_(std::exchange(rhs.data_, nullptr))
         , size_(std::exchange(rhs.size_, 0))
-        , streams_(rhs.streams_)
+        , streams_(std::exchange(rhs.streams_, {}))
         , allocator_(rhs.allocator_)
     {
     }
@@ -116,9 +116,13 @@ public:
     /// \return refrence to this buffer.
     buffer& operator=(buffer&& rhs)
     {
+        if (nullptr != data_)
+        {
+            allocator_.deallocate(data_, size_);
+        }
         data_      = std::exchange(rhs.data_, nullptr);
         size_      = std::exchange(rhs.size_, 0);
-        streams_   = rhs.streams_;
+        streams_   = std::exchange(rhs.streams_, {});
         allocator_ = rhs.allocator_;
         return *this;
     }

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -119,7 +119,7 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \return Unique pointer to Aligner object
 std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_target_length, int32_t max_alignments, AlignmentType type, cudaStream_t stream, int32_t device_id, int64_t max_device_memory_allocator_caching_size = -1);
 
-/// \brief Created Aligner object
+/// \brief Created FixedBandAligner object
 ///
 /// \param type Type of aligner to construct
 /// \param max_bandwidth Maximum bandwidth for the Ukkonen band
@@ -128,10 +128,10 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \param allocator Allocator to use for internal device memory allocations
 /// \param max_device_memory Maximum amount of device memory to use from passed in allocator in bytes (-1 for all available memory)
 ///
-/// \return Unique pointer to Aligner object
+/// \return Unique pointer to FixedBandAligner object
 std::unique_ptr<FixedBandAligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, DefaultDeviceAllocator allocator, int64_t max_device_memory);
 
-/// \brief Created Aligner object
+/// \brief Created FixedBandAligner object
 ///
 /// \param type Type of aligner to construct
 /// \param max_bandwidth Maximum bandwidth for the Ukkonen band
@@ -139,7 +139,7 @@ std::unique_ptr<FixedBandAligner> create_aligner(AlignmentType type, int32_t max
 /// \param device_id GPU device ID to run all CUDA operations on
 /// \param max_device_memory Maximum amount of device memory used in bytes (-1 (default) for all available memory).
 ///
-/// \return Unique pointer to Aligner object
+/// \return Unique pointer to FixedBandAligner object
 std::unique_ptr<FixedBandAligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, int64_t max_device_memory = -1);
 /// \}
 } // namespace cudaaligner

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/aligner.hpp
@@ -82,6 +82,17 @@ public:
     virtual void reset() = 0;
 };
 
+/// A special CUDA Aligner that works with a fixed band of the Needleman-Wunsch matrix.
+class FixedBandAligner : public Aligner
+{
+public:
+    /// \brief Reset the bandwidth of the Aligner.
+    ///
+    /// Resets all data of the aligner and resets the bandwidth to the given argument.
+    /// \param max_bandwidth The new maximal bandwidth to use for the fixed diagonal band of the Needleman-Wunsch matrix. Is not allowed to be a (multiple of 32) + 1. If such a value is passed it will throw and std::invalid_argument exception.
+    virtual void reset_max_bandwidth(int32_t max_bandwidth) = 0;
+};
+
 /// \brief Created Aligner object - DEPRECATED API
 ///
 /// \param max_query_length Maximum length of query string
@@ -118,7 +129,7 @@ std::unique_ptr<Aligner> create_aligner(int32_t max_query_length, int32_t max_ta
 /// \param max_device_memory Maximum amount of device memory to use from passed in allocator in bytes (-1 for all available memory)
 ///
 /// \return Unique pointer to Aligner object
-std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, DefaultDeviceAllocator allocator, int64_t max_device_memory);
+std::unique_ptr<FixedBandAligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, DefaultDeviceAllocator allocator, int64_t max_device_memory);
 
 /// \brief Created Aligner object
 ///
@@ -129,7 +140,7 @@ std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidt
 /// \param max_device_memory Maximum amount of device memory used in bytes (-1 (default) for all available memory).
 ///
 /// \return Unique pointer to Aligner object
-std::unique_ptr<Aligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, int64_t max_device_memory = -1);
+std::unique_ptr<FixedBandAligner> create_aligner(AlignmentType type, int32_t max_bandwidth, cudaStream_t stream, int32_t device_id, int64_t max_device_memory = -1);
 /// \}
 } // namespace cudaaligner
 

--- a/cudaaligner/src/aligner.cpp
+++ b/cudaaligner/src/aligner.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<Aligner> create_aligner(
     return create_aligner(max_query_length, max_target_length, max_alignments, type, allocator, stream, device_id);
 }
 
-std::unique_ptr<Aligner> create_aligner(
+std::unique_ptr<FixedBandAligner> create_aligner(
     const AlignmentType type,
     const int32_t max_bandwidth,
     cudaStream_t stream,
@@ -91,7 +91,7 @@ std::unique_ptr<Aligner> create_aligner(
     }
 }
 
-std::unique_ptr<Aligner> create_aligner(
+std::unique_ptr<FixedBandAligner> create_aligner(
     const AlignmentType type,
     const int32_t max_bandwidth,
     cudaStream_t stream,

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -90,7 +90,9 @@ memory_distribution split_available_memory(const int64_t max_device_memory, cons
     r.pmvs_matrix_memory    = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_pmvs_matrix);
     r.score_matrix_memory   = static_cast<int64_t>(fmax_device_memory / mem_req_total_per_bp * mem_req_score_matrix);
     r.remainder             = 0;
-    r.remainder             = max_device_memory - get_total_memory_required(r);
+    // Compute the required memory for this distribution (remainder=0) and
+    // and then compute the remainder with respect to max_device_memory:
+    r.remainder = max_device_memory - get_total_memory_required(r);
     return r;
 }
 

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -230,9 +230,6 @@ StatusType AlignerGlobalMyersBanded::add_alignment(const char* query, int32_t qu
         return StatusType::exceeded_max_alignments;
     }
 
-    // TODO handle reverse complements
-    assert(reverse_complement_query == false);
-    assert(reverse_complement_target == false);
     assert(get_size(seq_starts_h) % 2 == 1);
     const int64_t seq_start = seq_starts_h.back();
     genomeutils::copy_sequence(query, query_length, seq_h.data() + seq_start, reverse_complement_query);

--- a/cudaaligner/src/aligner_global_myers_banded.hpp
+++ b/cudaaligner/src/aligner_global_myers_banded.hpp
@@ -27,7 +27,7 @@ namespace genomeworks
 namespace cudaaligner
 {
 
-class AlignerGlobalMyersBanded : public Aligner
+class AlignerGlobalMyersBanded : public FixedBandAligner
 {
 public:
     AlignerGlobalMyersBanded(int64_t max_device_memory, int32_t max_bandwidth, DefaultDeviceAllocator allocator, cudaStream_t stream, int32_t device_id);
@@ -44,7 +44,7 @@ public:
         return alignments_;
     }
 
-    void reset_bandwidth(int32_t max_bandwidth);
+    void reset_max_bandwidth(int32_t max_bandwidth) override;
 
 private:
     struct InternalData;

--- a/cudaaligner/tests/Test_AlignerGlobal.cpp
+++ b/cudaaligner/tests/Test_AlignerGlobal.cpp
@@ -212,6 +212,19 @@ TEST(TestCudaAligner, TestAlignmentAddition)
     ASSERT_EQ(5, aligner->num_alignments());
 }
 
+TEST(TestFixedBandAligner, TestResetBandwidth)
+{
+    const int32_t max_bandwidth1              = 2048;
+    const int32_t max_bandwidth2              = 500;
+    DefaultDeviceAllocator allocator          = create_default_device_allocator();
+    std::unique_ptr<FixedBandAligner> aligner = std::make_unique<AlignerGlobalMyersBanded>(-1,
+                                                                                           max_bandwidth1,
+                                                                                           allocator,
+                                                                                           nullptr,
+                                                                                           0);
+    aligner->reset_max_bandwidth(max_bandwidth2);
+}
+
 TEST_P(TestAlignerGlobal, TestAlignmentKernel)
 {
     AlignerTestData param                                          = GetParam();
@@ -314,8 +327,6 @@ TEST_P(TestAlignerGlobal, TestAlignmentKernel)
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(TestCudaAligner, TestAlignerGlobal, ::testing::ValuesIn(create_aligner_test_cases()));
-
 TEST_P(TestAlignerGlobalImplPerf, TestAlignmentKernelPerf)
 {
     AlignerTestData param                                          = GetParam();
@@ -344,6 +355,7 @@ TEST_P(TestAlignerGlobalImplPerf, TestAlignmentKernelPerf)
     ASSERT_EQ(alignments.size(), inputs.size());
 }
 
+INSTANTIATE_TEST_SUITE_P(TestCudaAligner, TestAlignerGlobal, ::testing::ValuesIn(create_aligner_test_cases()));
 INSTANTIATE_TEST_SUITE_P(TestCudaAligner, TestAlignerGlobalImplPerf, ::testing::ValuesIn(create_aligner_perf_test_cases()));
 } // namespace cudaaligner
 


### PR DESCRIPTION
* Added an abstract base class FixedBandAligner (which provides a `aligner->reset_max_bandwidth(int32_t)`).
* Renamed `aligner->reset_bandwidth(int32_t)` to `aligner->reset_max_bandwidth(int32_t)`.
* Fixed a memory-leak in device_buffer's move-assignment