### PR TITLE
[cudamapper] Ignore -Wunused-parameter for Thrust

### DIFF
--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -15,7 +15,6 @@
 */
 
 #include "index_gpu.cuh"
-#include <thrust/transform_scan.h>
 
 namespace claraparabricks
 {

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -19,12 +19,15 @@
 #include <algorithm>
 #include <vector>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <thrust/adjacent_difference.h>
 #include <thrust/copy.h>
 #include <thrust/host_vector.h>
 #include <thrust/replace.h>
 #include <thrust/transform.h>
 #include <thrust/transform_scan.h>
+#pragma GCC diagnostic pop
 
 #include <claraparabricks/genomeworks/cudamapper/index.hpp>
 #include <claraparabricks/genomeworks/cudamapper/types.hpp>

--- a/cudamapper/src/matcher_gpu.cu
+++ b/cudamapper/src/matcher_gpu.cu
@@ -19,8 +19,11 @@
 #include <cassert>
 #include <numeric>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <thrust/transform_scan.h>
 #include <thrust/execution_policy.h>
+#pragma GCC diagnostic pop
 
 #include <claraparabricks/genomeworks/utils/cudasort.cuh>
 #include <claraparabricks/genomeworks/utils/cudautils.hpp>


### PR DESCRIPTION
Added pragmas for ignoring `-Wunused-parameter` in Thrust.

I only added it in needed places. @ahehn-nv do you think we should simply do it everywhere where Thrust is included?