### PR TITLE
[cudaaligner] Use RLE for alignment

### DIFF
--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
@@ -91,8 +91,12 @@ public:
     /// \return Vector of AlignmentState encoding sequence of match,
     ///         mistmatch and insertions in alignment.
     virtual const std::vector<AlignmentState>& get_alignment() const = 0;
-    virtual const std::vector<int8_t>& get_actions() const           = 0;
-    virtual const std::vector<int32_t>& get_runlengths() const       = 0;
+
+    /// \brief Gets the vector of actions (see AlignmentState) for the runlengt-encoded alignments (see also get_runlengths()).
+    virtual const std::vector<int8_t>& get_actions() const = 0;
+
+    /// \brief Gets the vector of runlengths. Each entry corresponds to the action at the same position (see get_actions()).
+    virtual const std::vector<int32_t>& get_runlengths() const = 0;
 
     /// \brief Get the edit distance corrsponding to the alignment
     ///

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
@@ -92,7 +92,7 @@ public:
     ///         mistmatch and insertions in alignment.
     virtual const std::vector<AlignmentState>& get_alignment() const = 0;
     virtual const std::vector<int8_t>& get_actions() const           = 0;
-    virtual const std::vector<uint8_t>& get_runlengths() const       = 0;
+    virtual const std::vector<int32_t>& get_runlengths() const       = 0;
 
     /// \brief Get the edit distance corrsponding to the alignment
     ///

--- a/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
+++ b/cudaaligner/include/claraparabricks/genomeworks/cudaaligner/alignment.hpp
@@ -91,6 +91,8 @@ public:
     /// \return Vector of AlignmentState encoding sequence of match,
     ///         mistmatch and insertions in alignment.
     virtual const std::vector<AlignmentState>& get_alignment() const = 0;
+    virtual const std::vector<int8_t>& get_actions() const           = 0;
+    virtual const std::vector<uint8_t>& get_runlengths() const       = 0;
 
     /// \brief Get the edit distance corrsponding to the alignment
     ///

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -175,7 +175,10 @@ void AlignerGlobalMyersBanded::reallocate_internal_data(InternalData* const data
     data->query_patterns = batched_device_matrices<WordType>();
     data->query_patterns.reserve_n_matrices(n_alignments_initial);
 
-    int64_t max_available_memory = allocator.get_size_of_largest_free_memory_block();
+    // In a single-threaded code the following exception should never trigger,
+    // because we just freed max_device_memory bytes and the new memory
+    // requirement will be max_device_memory bytes again.
+    const int64_t max_available_memory = allocator.get_size_of_largest_free_memory_block();
     if (max_available_memory < get_total_memory_required(mem))
     {
         throw std::runtime_error("Not enough contiguous device memory in device allocator.");

--- a/cudaaligner/src/aligner_global_myers_banded.cpp
+++ b/cudaaligner/src/aligner_global_myers_banded.cpp
@@ -222,7 +222,6 @@ StatusType AlignerGlobalMyersBanded::add_alignment(const char* query, int32_t qu
     if (query == nullptr || target == nullptr)
         return StatusType::generic_error;
 
-    scoped_device_switch dev(device_id_);
     auto& seq_h           = data_->seq_h;
     auto& seq_starts_h    = data_->seq_starts_h;
     auto& result_starts_h = data_->result_starts_h;

--- a/cudaaligner/src/alignment_impl.hpp
+++ b/cudaaligner/src/alignment_impl.hpp
@@ -101,7 +101,7 @@ public:
     ///
     /// \param alignment Alignment between sequences
     /// \param is_optimal true if the alignment is optimal, false if it is an approximation
-    virtual void set_alignment(const std::vector<int8_t>& action, const std::vector<uint8_t>& runlength, bool is_optimal)
+    virtual void set_alignment(const std::vector<int8_t>& action, const std::vector<int32_t>& runlength, bool is_optimal)
     {
         action_     = action;
         runlength_  = runlength;
@@ -122,7 +122,7 @@ public:
         return action_;
     }
 
-    const std::vector<uint8_t>& get_runlengths() const override
+    const std::vector<int32_t>& get_runlengths() const override
     {
         return runlength_;
     }
@@ -145,7 +145,7 @@ private:
     AlignmentType type_;
     std::vector<AlignmentState> alignment_;
     std::vector<int8_t> action_;
-    std::vector<uint8_t> runlength_;
+    std::vector<int32_t> runlength_;
     bool is_optimal_;
 };
 } // namespace cudaaligner

--- a/cudaaligner/src/alignment_impl.hpp
+++ b/cudaaligner/src/alignment_impl.hpp
@@ -97,6 +97,17 @@ public:
         is_optimal_ = is_optimal;
     }
 
+    /// \brief Set alignment between sequences.
+    ///
+    /// \param alignment Alignment between sequences
+    /// \param is_optimal true if the alignment is optimal, false if it is an approximation
+    virtual void set_alignment(const std::vector<int8_t>& action, const std::vector<uint8_t>& runlength, bool is_optimal)
+    {
+        action_     = action;
+        runlength_  = runlength;
+        is_optimal_ = is_optimal;
+    }
+
     /// \brief Get the alignment between sequences
     ///
     /// \return Vector of AlignmentState encoding sequence of match,
@@ -123,6 +134,8 @@ private:
     StatusType status_;
     AlignmentType type_;
     std::vector<AlignmentState> alignment_;
+    std::vector<int8_t> action_;
+    std::vector<uint8_t> runlength_;
     bool is_optimal_;
 };
 } // namespace cudaaligner

--- a/cudaaligner/src/alignment_impl.hpp
+++ b/cudaaligner/src/alignment_impl.hpp
@@ -117,6 +117,16 @@ public:
         return alignment_;
     }
 
+    const std::vector<int8_t>& get_actions() const override
+    {
+        return action_;
+    }
+
+    const std::vector<uint8_t>& get_runlengths() const override
+    {
+        return runlength_;
+    }
+
     /// \brief Get the edit distance corrsponding to the alignment
     ///
     /// Returns the number of edits of the found alignment.

--- a/cudaaligner/src/myers_gpu.cu
+++ b/cudaaligner/src/myers_gpu.cu
@@ -585,7 +585,7 @@ __device__ int32_t myers_backtrace_banded(int8_t* path, uint8_t* const path_coun
             prev_r  = static_cast<int8_t>(AlignmentState::deletion);
             r_count = 0;
         }
-        const int32_t decrement = max(i, static_cast<int32_t>(r_count_max) - static_cast<int32_t>(r_count));
+        const int32_t decrement = min(i, static_cast<int32_t>(r_count_max) - static_cast<int32_t>(r_count));
         r_count += static_cast<uint8_t>(decrement);
         i -= decrement;
     }
@@ -602,7 +602,7 @@ __device__ int32_t myers_backtrace_banded(int8_t* path, uint8_t* const path_coun
             prev_r  = static_cast<int8_t>(AlignmentState::insertion);
             r_count = 0;
         }
-        const int32_t decrement = max(j, static_cast<int32_t>(r_count_max) - static_cast<int32_t>(r_count));
+        const int32_t decrement = min(j, static_cast<int32_t>(r_count_max) - static_cast<int32_t>(r_count));
         r_count += static_cast<uint8_t>(decrement);
         j -= decrement;
     }

--- a/cudaaligner/src/myers_gpu.cuh
+++ b/cudaaligner/src/myers_gpu.cuh
@@ -50,7 +50,7 @@ void myers_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length
                batched_device_matrices<myers::WordType>& query_patterns,
                cudaStream_t stream);
 
-void myers_banded_gpu(int8_t* paths_d, uint8_t* path_counts_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
+void myers_banded_gpu(int8_t* paths_d, int32_t* path_counts_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
                       char const* sequences_d,
                       int64_t const* sequence_starts_d,
                       int32_t const* scheduling_index_d,

--- a/cudaaligner/src/myers_gpu.cuh
+++ b/cudaaligner/src/myers_gpu.cuh
@@ -50,7 +50,7 @@ void myers_gpu(int8_t* paths_d, int32_t* path_lengths_d, int32_t max_path_length
                batched_device_matrices<myers::WordType>& query_patterns,
                cudaStream_t stream);
 
-void myers_banded_gpu(int8_t* paths_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
+void myers_banded_gpu(int8_t* paths_d, uint8_t* path_counts_d, int32_t* path_lengths_d, int64_t const* path_starts_d,
                       char const* sequences_d,
                       int64_t const* sequence_starts_d,
                       int32_t const* scheduling_index_d,

--- a/cudaaligner/tests/Test_AlignerGlobal.cpp
+++ b/cudaaligner/tests/Test_AlignerGlobal.cpp
@@ -134,13 +134,25 @@ std::vector<AlignerTestData> create_aligner_test_cases()
     test_cases.push_back(data);
 
     std::vector<AlignerTestData> test_cases_final;
-    test_cases_final.reserve(4 * test_cases.size());
     test_cases_final.insert(test_cases_final.end(), test_cases.begin(), test_cases.end());
     std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::Ukkonen; return td; });
     std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::Myers; return td; });
     std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::MyersBanded; return td; });
     std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::HirschbergMyers; return td; });
 
+    // Add special cases to algorithms that support it
+    test_cases.clear();
+    data.inputs    = {{"", "GACTCTCCCCCTCCCCTTTAAATATATAAAAATGGGGTGTAGCTAG"}, {"GACTCTCCCCCTCCCCTTTAAATATATAAAAATGGGGTGTAGCTAG", ""}, {"", ""}};
+    data.cigars    = {"46I", "46D", ""};
+    data.edit_dist = {46, 46, 0};
+    data.algorithm = AlignmentAlgorithm::Default;
+    test_cases.push_back(data);
+    test_cases_final.insert(test_cases_final.end(), test_cases.begin(), test_cases.end());
+    // Ukkonen cannot handle these cases:
+    // std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::Ukkonen; return td; });
+    std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::Myers; return td; });
+    std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::MyersBanded; return td; });
+    std::transform(test_cases.begin(), test_cases.end(), std::back_inserter(test_cases_final), [](AlignerTestData td) { td.algorithm = AlignmentAlgorithm::HirschbergMyers; return td; });
     return test_cases_final;
 }
 
@@ -313,7 +325,7 @@ TEST_P(TestAlignerGlobal, TestAlignmentKernel)
                                                                 << "\nand\n"
                                                                 << alignment->get_target_sequence()
                                                                 << "\nindex: " << a
-                                                                << "\nusing " << get_algorithm_name(param.algorithm);
+                                                                << " using " << get_algorithm_name(param.algorithm);
         }
         if (!edit_distances.empty())
         {
@@ -322,7 +334,7 @@ TEST_P(TestAlignerGlobal, TestAlignmentKernel)
                                                                          << "\nand\n"
                                                                          << alignment->get_target_sequence()
                                                                          << "\nindex: " << a
-                                                                         << "\nusing " << get_algorithm_name(param.algorithm);
+                                                                         << " using " << get_algorithm_name(param.algorithm);
         }
     }
 }


### PR DESCRIPTION
* Instead of storing a flat sequence of `AlignmentType` operations, the aligner now stores a sequence of `AlignmentType` operations ("actions") and a sequence of `counts` which runlength-encode the flat sequence.
* Added functions to the `AlignmentImpl` class to store and obtain the RLE sequences and convert them to a CIGAR string. The class maintains backward compatibility for aligners that still provide the flat sequence. Those aligners need to be adapted in the future.
* banded Myers algorithm: Handle special cases, where query length and/or target length are 0.